### PR TITLE
feat: cta-rotator (Fixes #6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "test": "node --test \"tests/**/*.mjs\""
   },
   "dependencies": {
     "@astrojs/tailwind": "^5.1.0",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,8 @@ import BannerSlot from '../components/BannerSlot.astro';
 import MainLayout from '../layouts/MainLayout.astro';
 import { buildTrackedLink, withBase } from '../utils/links';
 
+const HERO_CTA_PLACEHOLDER = 'https://linktr.ee/naughtycamspot';
+
 const featuredMuse = {
   name: 'Anna Prince',
   archetype: 'Stripchat • Velvet strategist',
@@ -118,7 +120,7 @@ const jsonLd = {
                 path: '/go/model-join.php',
                 slot: 'home_hero',
                 camp: 'home',
-                placeholder: 'https://bongacams.com/model-signup'
+                placeholder: HERO_CTA_PLACEHOLDER
               })}
               target="_blank"
               rel="noreferrer"

--- a/src/utils/links.d.ts
+++ b/src/utils/links.d.ts
@@ -1,0 +1,13 @@
+export type BuildTrackedLinkOptions = {
+  path: string;
+  slot: string;
+  camp: string;
+  placeholder: string;
+};
+
+export declare const isPagesBuild: () => boolean;
+export declare const withBase: (path?: string) => string;
+export declare const buildTrackedLink: (options: BuildTrackedLinkOptions) => string;
+export declare const __test: {
+  formatDateStamp: () => string;
+};

--- a/src/utils/links.js
+++ b/src/utils/links.js
@@ -1,4 +1,14 @@
-const BASE_URL = import.meta.env.BASE_URL || '/';
+const runtimeBaseUrl =
+  typeof import.meta !== 'undefined' && typeof import.meta.env !== 'undefined'
+    ? import.meta.env.BASE_URL
+    : undefined;
+
+const envBaseUrl =
+  typeof process !== 'undefined' && process.env
+    ? process.env.ASTRO_BASE_URL ?? process.env.BASE_URL
+    : undefined;
+
+const BASE_URL = runtimeBaseUrl ?? envBaseUrl ?? '/';
 const IS_PAGES_BUILD = BASE_URL !== '/';
 
 const formatDateStamp = () => {
@@ -11,7 +21,7 @@ const formatDateStamp = () => {
 
 export const isPagesBuild = () => IS_PAGES_BUILD;
 
-export const withBase = (path = ''): string => {
+export const withBase = (path = '') => {
   const cleanedPath = path.startsWith('/') ? path.slice(1) : path;
   if (!cleanedPath) {
     return BASE_URL;
@@ -20,17 +30,7 @@ export const withBase = (path = ''): string => {
   return `${BASE_URL}${cleanedPath}`;
 };
 
-export const buildTrackedLink = ({
-  path,
-  slot,
-  camp,
-  placeholder
-}: {
-  path: string;
-  slot: string;
-  camp: string;
-  placeholder: string;
-}): string => {
+export const buildTrackedLink = ({ path, slot, camp, placeholder }) => {
   if (IS_PAGES_BUILD) {
     return placeholder;
   }
@@ -41,3 +41,5 @@ export const buildTrackedLink = ({
 
   return `${normalizedPath}${queryGlue}${tracking}`;
 };
+
+export const __test = { formatDateStamp };

--- a/tests/home-hero-cta.test.mjs
+++ b/tests/home-hero-cta.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+const placeholder = 'https://linktr.ee/naughtycamspot';
+const importLinksWithBase = async (baseUrl) => {
+  const previousBase = process.env.ASTRO_BASE_URL;
+  process.env.ASTRO_BASE_URL = baseUrl;
+  const module = await import(`../src/utils/links.js?base=${baseUrl}`);
+  process.env.ASTRO_BASE_URL = previousBase;
+  return module;
+};
+
+test('Pages build uses external placeholder link', async () => {
+  const { buildTrackedLink } = await importLinksWithBase('/docs/');
+  const href = buildTrackedLink({
+    path: '/go/model-join.php',
+    slot: 'home_hero',
+    camp: 'home',
+    placeholder
+  });
+
+  const anchorSnapshot = `<a href="${href}"></a>`;
+  assert.equal(anchorSnapshot, '<a href="https://linktr.ee/naughtycamspot"></a>');
+});
+
+test('Production build outputs tracked /go link', async () => {
+  const { buildTrackedLink, __test } = await importLinksWithBase('/');
+  const href = buildTrackedLink({
+    path: '/go/model-join.php',
+    slot: 'home_hero',
+    camp: 'home',
+    placeholder
+  });
+
+  const dateStamp = __test.formatDateStamp();
+  assert.equal(dateStamp.length, 8);
+  assert.equal(/^\d{8}$/.test(dateStamp), true);
+
+  const anchorSnapshot = `<a href="${href}"></a>`;
+  assert.equal(
+    anchorSnapshot,
+    `<a href="/go/model-join.php?src=home_hero&camp=home&date=${dateStamp}"></a>`
+  );
+});


### PR DESCRIPTION
## Summary
- route the home hero CTA to a safe external placeholder in Pages builds while keeping the tracked /go link for production
- add a node-based DOM snapshot test that verifies the hero CTA target for Pages and production build modes
- expose utility fallbacks and a test script so the link helper can be exercised outside Astro

## Testing
- npm test
- npm run build

## Checklist
- Pages preview URL: _pending from CI deploy_
- No `/go/*` links emitted on Pages.
- `astro.config.mjs` (prod) unchanged.
- Screenshots: _no visual changes to capture_
- Fixes #6

------
https://chatgpt.com/codex/tasks/task_e_68f1f09372988326b3b9db64864515c0