### PR TITLE
feat: rotator (Fixes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Luxury gallery frontend for Naughty Cam Spot, built with Astro and Tailwind CSS.
 - Install dependencies: `npm install`
 - Start local dev server: `npm run dev`
 - Create a production build: `npm run build`
+- Build for GitHub Pages: `npm run build:pages`
 
 ## Project structure
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "build:pages": "astro build --config astro.config.pages.mjs",
     "preview": "astro preview",
     "test": "node --test \"tests/**/*.mjs\""
   },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,37 @@
 ---
 import BannerSlot from '../components/BannerSlot.astro';
 import MainLayout from '../layouts/MainLayout.astro';
-import { buildTrackedLink, withBase } from '../utils/links';
+import { buildTrackedLink, isPagesBuild, withBase } from '../utils/links';
+import {
+  BONGA_COUNTRY_TIERS,
+  BONGA_TIER_ORDER,
+  DEFAULT_TIER,
+  MODEL_SIGNUP_PROGRAMS,
+  getDefaultModelProgram
+} from '../utils/model-rotator';
 
 const HERO_CTA_PLACEHOLDER = 'https://linktr.ee/naughtycamspot';
+
+const pagesBuild = isPagesBuild();
+const modelProgram = getDefaultModelProgram();
+const heroCtaSlot = 'home_hero';
+const heroCtaCamp = 'home';
+const heroCtaPath = modelProgram?.path ?? '/go/model-join.php';
+
+const heroCtaHref = buildTrackedLink({
+  path: heroCtaPath,
+  slot: heroCtaSlot,
+  camp: heroCtaCamp,
+  placeholder: HERO_CTA_PLACEHOLDER
+});
+
+const safeStringify = (value: unknown) => JSON.stringify(value).replace(/</g, '\\u003c');
+const modelRotatorPayload = safeStringify({
+  programs: MODEL_SIGNUP_PROGRAMS,
+  tierMap: BONGA_COUNTRY_TIERS,
+  tierOrder: BONGA_TIER_ORDER,
+  defaultTier: DEFAULT_TIER
+});
 
 const featuredMuse = {
   name: 'Anna Prince',
@@ -116,12 +144,10 @@ const jsonLd = {
           <div class="flex flex-col gap-4 sm:flex-row">
             <a
               class="flex items-center justify-center rounded-full border border-rose-gold/60 bg-rose-gold px-6 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-midnight shadow-glow transition hover:-translate-y-1"
-              href={buildTrackedLink({
-                path: '/go/model-join.php',
-                slot: 'home_hero',
-                camp: 'home',
-                placeholder: HERO_CTA_PLACEHOLDER
-              })}
+              href={heroCtaHref}
+              data-model-rotator="model-join"
+              data-slot={heroCtaSlot}
+              data-camp={heroCtaCamp}
               target="_blank"
               rel="noreferrer"
             >
@@ -314,4 +340,122 @@ const jsonLd = {
 
   <!-- SLOT: home_footer_leaderboard -->
   <BannerSlot slotId="home_footer_leaderboard" class="mt-16" />
+
+  {!pagesBuild && (
+    <script is:inline type="module">
+      const payload = JSON.parse('{modelRotatorPayload}');
+      const { programs, tierMap, tierOrder, defaultTier } = payload;
+
+      const formatDateStamp = () => {
+        const now = new Date();
+        const year = String(now.getUTCFullYear());
+        const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+        const day = String(now.getUTCDate()).padStart(2, '0');
+        return `${year}${month}${day}`;
+      };
+
+      const buildTrackedHref = (path, slot, camp) => {
+        if (!path) return undefined;
+        const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+        const glue = normalizedPath.includes('?') ? '&' : '?';
+        const date = formatDateStamp();
+        return `${normalizedPath}${glue}src=${encodeURIComponent(slot)}&camp=${encodeURIComponent(camp)}&date=${date}`;
+      };
+
+      const parseLocaleToCountry = (locale) => {
+        if (!locale || typeof locale !== 'string') return undefined;
+        const match = locale.toUpperCase().match(/[-_]([A-Z]{2})$/);
+        return match ? match[1] : undefined;
+      };
+
+      const collectLocales = () => {
+        const locales = new Set();
+        if (Array.isArray(navigator.languages)) {
+          navigator.languages.forEach((lang) => locales.add(lang));
+        }
+
+        if (navigator.language) {
+          locales.add(navigator.language);
+        }
+
+        try {
+          const resolved = Intl.DateTimeFormat().resolvedOptions().locale;
+          if (resolved) {
+            locales.add(resolved);
+          }
+        } catch (error) {
+          // ignore
+        }
+
+        return Array.from(locales);
+      };
+
+      const findProgramForTier = (tier) => {
+        const activePrograms = programs.filter((program) => program.active !== false);
+        if (activePrograms.length === 0) {
+          return undefined;
+        }
+
+        const startingIndex = Math.max(tierOrder.indexOf(tier), 0);
+        for (let index = startingIndex; index < tierOrder.length; index += 1) {
+          const currentTier = tierOrder[index];
+          const match = activePrograms.find((program) =>
+            Array.isArray(program.tiers) && program.tiers.includes(currentTier)
+          );
+
+          if (match) {
+            return match;
+          }
+        }
+
+        return activePrograms[0];
+      };
+
+      const detectCountry = () => {
+        const locales = collectLocales();
+        for (const locale of locales) {
+          const country = parseLocaleToCountry(locale);
+          if (country) {
+            return country;
+          }
+        }
+
+        return undefined;
+      };
+
+      const applyRotator = () => {
+        const anchors = document.querySelectorAll('[data-model-rotator="model-join"]');
+        if (!anchors.length) {
+          return;
+        }
+
+        const country = detectCountry();
+        const tier = (country && tierMap[country]) || defaultTier;
+        const program = findProgramForTier(tier);
+
+        if (!program) {
+          return;
+        }
+
+        anchors.forEach((anchor) => {
+          const slot = anchor.dataset.slot;
+          const camp = anchor.dataset.camp;
+          if (!slot || !camp) {
+            return;
+          }
+
+          const href = buildTrackedHref(program.path, slot, camp);
+          if (href) {
+            anchor.href = href;
+          }
+        });
+      };
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', applyRotator, { once: true });
+      } else {
+        applyRotator();
+      }
+    </script>
+  )}
 </MainLayout>

--- a/src/utils/model-rotator.d.ts
+++ b/src/utils/model-rotator.d.ts
@@ -1,0 +1,28 @@
+export type BongaTier = 'tier1' | 'tier2' | 'tier3';
+
+export type ModelProgram = {
+  id: string;
+  label: string;
+  path: string;
+  tiers: BongaTier[];
+  active?: boolean;
+};
+
+export declare const BONGA_TIER_ORDER: readonly BongaTier[];
+export declare const DEFAULT_TIER: BongaTier;
+export declare const MODEL_SIGNUP_PROGRAMS: readonly ModelProgram[];
+export declare const BONGA_COUNTRY_TIERS: Record<string, BongaTier>;
+export declare const getDefaultModelProgram: () => ModelProgram | undefined;
+export declare const getModelSignupProgramByCountry: (
+  countryCode?: string,
+  programs?: readonly ModelProgram[]
+) => ModelProgram | undefined;
+export declare const parseLocaleToCountry: (locale?: string) => string | undefined;
+
+export declare const __test: {
+  findProgramForTier: (
+    tier: BongaTier,
+    programs?: readonly ModelProgram[]
+  ) => ModelProgram | undefined;
+  getActivePrograms: (programs?: readonly ModelProgram[]) => readonly ModelProgram[];
+};

--- a/src/utils/model-rotator.js
+++ b/src/utils/model-rotator.js
@@ -1,0 +1,148 @@
+const BONGA_TIER_ORDER = ['tier1', 'tier2', 'tier3'];
+const DEFAULT_TIER = 'tier3';
+
+const MODEL_SIGNUP_PROGRAMS = [
+  {
+    id: 'bonga_tier1',
+    label: 'BongaCams • Tier 1',
+    path: '/go/model-join.php',
+    tiers: ['tier1'],
+    active: true
+  },
+  {
+    id: 'bonga_tier2',
+    label: 'BongaCams • Tier 2',
+    path: '/go/model-join-tier2.php',
+    tiers: ['tier2'],
+    active: true
+  },
+  {
+    id: 'bonga_tier3',
+    label: 'BongaCams • Global',
+    path: '/go/model-join-tier3.php',
+    tiers: ['tier3'],
+    active: true
+  }
+];
+
+const BONGA_COUNTRY_TIERS = {
+  US: 'tier1',
+  CA: 'tier1',
+  GB: 'tier1',
+  DE: 'tier1',
+  FR: 'tier1',
+  IT: 'tier1',
+  ES: 'tier1',
+  AU: 'tier1',
+  NZ: 'tier1',
+  NL: 'tier1',
+  SE: 'tier1',
+  NO: 'tier1',
+  DK: 'tier1',
+  FI: 'tier1',
+  IE: 'tier1',
+  BE: 'tier1',
+  AT: 'tier1',
+  CH: 'tier1',
+  JP: 'tier1',
+  SG: 'tier1',
+  KR: 'tier1',
+  AE: 'tier1',
+  KW: 'tier1',
+  SA: 'tier1',
+  QA: 'tier1',
+  BH: 'tier1',
+  OM: 'tier1',
+  BR: 'tier2',
+  MX: 'tier2',
+  AR: 'tier2',
+  CL: 'tier2',
+  CO: 'tier2',
+  PE: 'tier2',
+  UY: 'tier2',
+  PY: 'tier2',
+  BO: 'tier2',
+  CR: 'tier2',
+  PA: 'tier2',
+  GT: 'tier2',
+  HN: 'tier2',
+  NI: 'tier2',
+  SV: 'tier2',
+  DO: 'tier2',
+  PR: 'tier2',
+  VE: 'tier2',
+  EC: 'tier2',
+  PH: 'tier2',
+  TH: 'tier2',
+  MY: 'tier2',
+  ID: 'tier2',
+  VN: 'tier2',
+  IN: 'tier2',
+  PL: 'tier2',
+  CZ: 'tier2',
+  HU: 'tier2',
+  SK: 'tier2',
+  SI: 'tier2',
+  RO: 'tier2',
+  BG: 'tier2',
+  HR: 'tier2',
+  RS: 'tier2',
+  GR: 'tier2',
+  TR: 'tier2'
+};
+
+const getActivePrograms = (programs = MODEL_SIGNUP_PROGRAMS) =>
+  programs.filter((program) => program.active !== false);
+
+const findProgramForTier = (tier, programs = MODEL_SIGNUP_PROGRAMS) => {
+  const activePrograms = getActivePrograms(programs);
+  if (activePrograms.length === 0) {
+    return undefined;
+  }
+
+  const startIndex = Math.max(BONGA_TIER_ORDER.indexOf(tier), 0);
+  for (let index = startIndex; index < BONGA_TIER_ORDER.length; index += 1) {
+    const currentTier = BONGA_TIER_ORDER[index];
+    const match = activePrograms.find((program) =>
+      Array.isArray(program.tiers) && program.tiers.includes(currentTier)
+    );
+
+    if (match) {
+      return match;
+    }
+  }
+
+  return activePrograms[0];
+};
+
+const getModelSignupProgramByCountry = (countryCode, programs = MODEL_SIGNUP_PROGRAMS) => {
+  const normalizedCountry = countryCode ? countryCode.toUpperCase() : undefined;
+  const tier = normalizedCountry ? BONGA_COUNTRY_TIERS[normalizedCountry] ?? DEFAULT_TIER : DEFAULT_TIER;
+  return findProgramForTier(tier, programs);
+};
+
+const getDefaultModelProgram = () => findProgramForTier(DEFAULT_TIER);
+
+const parseLocaleToCountry = (locale) => {
+  if (!locale || typeof locale !== 'string') {
+    return undefined;
+  }
+
+  const matcher = locale.toUpperCase().match(/[-_]([A-Z]{2})$/);
+  return matcher ? matcher[1] : undefined;
+};
+
+export {
+  BONGA_COUNTRY_TIERS,
+  BONGA_TIER_ORDER,
+  DEFAULT_TIER,
+  MODEL_SIGNUP_PROGRAMS,
+  getDefaultModelProgram,
+  getModelSignupProgramByCountry,
+  parseLocaleToCountry
+};
+
+export const __test = {
+  findProgramForTier,
+  getActivePrograms
+};

--- a/tests/model-rotator.test.mjs
+++ b/tests/model-rotator.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+const importRotator = async () => import('../src/utils/model-rotator.js');
+
+test('selects tier 1 program for US visitors', async () => {
+  const { getModelSignupProgramByCountry } = await importRotator();
+  const program = getModelSignupProgramByCountry('US');
+
+  assert.ok(program, 'expected a program to be returned');
+  assert.equal(program.id, 'bonga_tier1');
+  assert.equal(program.path, '/go/model-join.php');
+});
+
+test('falls back to next active tier when preferred program is inactive', async () => {
+  const { __test } = await importRotator();
+  const mockPrograms = [
+    { id: 'tier1', path: '/go/tier1.php', tiers: ['tier1'], active: false },
+    { id: 'tier2', path: '/go/tier2.php', tiers: ['tier2'], active: true },
+    { id: 'tier3', path: '/go/tier3.php', tiers: ['tier3'], active: true }
+  ];
+
+  const program = __test.findProgramForTier('tier1', mockPrograms);
+  assert.ok(program, 'expected fallback program to be returned');
+  assert.equal(program.id, 'tier2');
+});
+
+test('parseLocaleToCountry extracts region codes', async () => {
+  const { parseLocaleToCountry } = await importRotator();
+  assert.equal(parseLocaleToCountry('en-US'), 'US');
+  assert.equal(parseLocaleToCountry('pt_br'), 'BR');
+  assert.equal(parseLocaleToCountry('invalid'), undefined);
+});


### PR DESCRIPTION
## Summary
- add a geo-aware model signup rotator for the hero CTA using Bonga tier routing
- ensure production builds emit tracked /go links while Pages builds stay on external placeholders
- document the Pages build entry point and add coverage for the rotator utility

## Testing
- npm test

## Pages
- URL: https://leecuevasowner.github.io/naughtycamspot

## Screenshots
- ![Homepage hero](browser:/invocations/tdquomfm/artifacts/artifacts/hero.png)

------
https://chatgpt.com/codex/tasks/task_e_68f1f61c54ec8326af057db328db8f27