### PR TITLE
feat: banners (Fixes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,31 @@ Luxury gallery frontend for Naughty Cam Spot, built with Astro and Tailwind CSS.
 - `images/` — shared static assets ready to surface in future sections
 
 Legacy HTML pages, generators, and blog scaffolding have been removed. Work forward from the Astro surface for new sections and routes.
+
+## Banner slots
+
+Banner placement is configured in `src/data/banners.ts`. Each slot defines its `/go/*` path for production, a Pages-safe placeholder link, SVG creative, explicit dimensions, and descriptive alt text.
+
+Current slots:
+
+- `home_top_leaderboard`
+- `home_mid_rectangle`
+- `home_footer_leaderboard`
+- `model_sidebar_tall`
+- `model_mid_rectangle`
+- `post_top_strip`
+- `post_inline_rect`
+- `post_end_strip`
+
+SVG placeholders for every slot live in `public/ads/`. Update these assets if creative direction changes, but avoid embedding third-party ad scripts.
+
+### Adding a new slot
+
+1. Define the slot in `src/data/banners.ts` with a unique `id`, production `/go/*` path, Pages placeholder URL, camp grouping, image path, dimensions, and alt text.
+2. Drop a matching SVG into `public/ads/` so Pages previews have local creative.
+3. Render the slot with `<BannerSlot id="slot_id" />` in the page or layout where it should appear, adding a `<!-- SLOT: slot_id -->` comment for quick scanning.
+
+### Link behaviour
+
+- **Pages builds (`astro.config.pages.mjs`)** use the placeholder URLs from the data file. These must be safe external links and must not start with `/go/` so GitHub Pages previews work.
+- **Production builds** use the `/go/*` slugs and automatically append `?src=<slot>&camp=<page>&date=YYYYMMDD` tracking parameters via the shared `buildTrackedLink` helper.

--- a/public/ads/home_footer_leaderboard.svg
+++ b/public/ads/home_footer_leaderboard.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="250" viewBox="0 0 1200 250">
+  <rect width="1200" height="250" fill="#111827" rx="24" />
+  <rect width="1200" height="250" fill="url(#glow)" rx="24" opacity="0.85" />
+  <defs>
+    <linearGradient id="glow" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f4a2b2" stop-opacity="0.45" />
+      <stop offset="1" stop-color="#4b5563" stop-opacity="0.7" />
+    </linearGradient>
+  </defs>
+  <text x="50%" y="48%" text-anchor="middle" fill="#fde8f0" font-family="'Work Sans', Arial, sans-serif" font-size="42" font-weight="600">
+    Home Footer Leaderboard
+  </text>
+  <text x="50%" y="70%" text-anchor="middle" fill="#fce7f3" font-family="'Work Sans', Arial, sans-serif" font-size="24" font-weight="400">
+    1200 × 250
+  </text>
+</svg>

--- a/public/ads/home_mid_rectangle.svg
+++ b/public/ads/home_mid_rectangle.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="500" viewBox="0 0 600 500">
+  <rect width="600" height="500" fill="#111827" rx="36" />
+  <rect width="600" height="500" fill="url(#glow)" rx="36" opacity="0.88" />
+  <defs>
+    <linearGradient id="glow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f4a2b2" stop-opacity="0.5" />
+      <stop offset="1" stop-color="#374151" stop-opacity="0.8" />
+    </linearGradient>
+  </defs>
+  <text x="50%" y="46%" text-anchor="middle" fill="#fde8f0" font-family="'Work Sans', Arial, sans-serif" font-size="34" font-weight="600">
+    Home Mid Rectangle
+  </text>
+  <text x="50%" y="62%" text-anchor="middle" fill="#fce7f3" font-family="'Work Sans', Arial, sans-serif" font-size="22" font-weight="400">
+    600 × 500
+  </text>
+</svg>

--- a/public/ads/home_top_leaderboard.svg
+++ b/public/ads/home_top_leaderboard.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="250" viewBox="0 0 1200 250">
+  <rect width="1200" height="250" fill="#111827" rx="24" />
+  <rect width="1200" height="250" fill="url(#glow)" rx="24" opacity="0.85" />
+  <defs>
+    <linearGradient id="glow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f4a2b2" stop-opacity="0.45" />
+      <stop offset="1" stop-color="#4b5563" stop-opacity="0.7" />
+    </linearGradient>
+  </defs>
+  <text x="50%" y="48%" text-anchor="middle" fill="#fde8f0" font-family="'Work Sans', Arial, sans-serif" font-size="42" font-weight="600">
+    Home Top Leaderboard
+  </text>
+  <text x="50%" y="70%" text-anchor="middle" fill="#fce7f3" font-family="'Work Sans', Arial, sans-serif" font-size="24" font-weight="400">
+    1200 × 250
+  </text>
+</svg>

--- a/public/ads/model_mid_rectangle.svg
+++ b/public/ads/model_mid_rectangle.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="500" viewBox="0 0 600 500">
+  <rect width="600" height="500" fill="#111827" rx="36" />
+  <rect width="600" height="500" fill="url(#glow)" rx="36" opacity="0.9" />
+  <defs>
+    <linearGradient id="glow" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f4a2b2" stop-opacity="0.5" />
+      <stop offset="1" stop-color="#374151" stop-opacity="0.85" />
+    </linearGradient>
+  </defs>
+  <text x="50%" y="46%" text-anchor="middle" fill="#fde8f0" font-family="'Work Sans', Arial, sans-serif" font-size="34" font-weight="600">
+    Model Mid Rectangle
+  </text>
+  <text x="50%" y="62%" text-anchor="middle" fill="#fce7f3" font-family="'Work Sans', Arial, sans-serif" font-size="22" font-weight="400">
+    600 × 500
+  </text>
+</svg>

--- a/public/ads/model_sidebar_tall.svg
+++ b/public/ads/model_sidebar_tall.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="720" viewBox="0 0 360 720">
+  <rect width="360" height="720" fill="#111827" rx="28" />
+  <rect width="360" height="720" fill="url(#glow)" rx="28" opacity="0.9" />
+  <defs>
+    <linearGradient id="glow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f4a2b2" stop-opacity="0.5" />
+      <stop offset="1" stop-color="#1f2937" stop-opacity="0.85" />
+    </linearGradient>
+  </defs>
+  <text x="50%" y="45%" text-anchor="middle" fill="#fde8f0" font-family="'Work Sans', Arial, sans-serif" font-size="28" font-weight="600">
+    Model Sidebar Tall
+  </text>
+  <text x="50%" y="56%" text-anchor="middle" fill="#fce7f3" font-family="'Work Sans', Arial, sans-serif" font-size="22" font-weight="400">
+    360 × 720
+  </text>
+</svg>

--- a/public/ads/post_end_strip.svg
+++ b/public/ads/post_end_strip.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="200" viewBox="0 0 900 200">
+  <rect width="900" height="200" fill="#111827" rx="24" />
+  <rect width="900" height="200" fill="url(#glow)" rx="24" opacity="0.87" />
+  <defs>
+    <linearGradient id="glow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f4a2b2" stop-opacity="0.48" />
+      <stop offset="1" stop-color="#4b5563" stop-opacity="0.78" />
+    </linearGradient>
+  </defs>
+  <text x="50%" y="48%" text-anchor="middle" fill="#fde8f0" font-family="'Work Sans', Arial, sans-serif" font-size="36" font-weight="600">
+    Post End Strip
+  </text>
+  <text x="50%" y="70%" text-anchor="middle" fill="#fce7f3" font-family="'Work Sans', Arial, sans-serif" font-size="22" font-weight="400">
+    900 × 200
+  </text>
+</svg>

--- a/public/ads/post_inline_rect.svg
+++ b/public/ads/post_inline_rect.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400">
+  <rect width="600" height="400" fill="#111827" rx="32" />
+  <rect width="600" height="400" fill="url(#glow)" rx="32" opacity="0.88" />
+  <defs>
+    <linearGradient id="glow" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f4a2b2" stop-opacity="0.5" />
+      <stop offset="1" stop-color="#374151" stop-opacity="0.8" />
+    </linearGradient>
+  </defs>
+  <text x="50%" y="46%" text-anchor="middle" fill="#fde8f0" font-family="'Work Sans', Arial, sans-serif" font-size="32" font-weight="600">
+    Post Inline Rect
+  </text>
+  <text x="50%" y="62%" text-anchor="middle" fill="#fce7f3" font-family="'Work Sans', Arial, sans-serif" font-size="22" font-weight="400">
+    600 × 400
+  </text>
+</svg>

--- a/public/ads/post_top_strip.svg
+++ b/public/ads/post_top_strip.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="150" viewBox="0 0 900 150">
+  <rect width="900" height="150" fill="#111827" rx="20" />
+  <rect width="900" height="150" fill="url(#glow)" rx="20" opacity="0.85" />
+  <defs>
+    <linearGradient id="glow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f4a2b2" stop-opacity="0.45" />
+      <stop offset="1" stop-color="#4b5563" stop-opacity="0.75" />
+    </linearGradient>
+  </defs>
+  <text x="50%" y="50%" text-anchor="middle" fill="#fde8f0" font-family="'Work Sans', Arial, sans-serif" font-size="34" font-weight="600">
+    Post Top Strip
+  </text>
+  <text x="50%" y="72%" text-anchor="middle" fill="#fce7f3" font-family="'Work Sans', Arial, sans-serif" font-size="22" font-weight="400">
+    900 × 150
+  </text>
+</svg>

--- a/src/components/BannerSlot.astro
+++ b/src/components/BannerSlot.astro
@@ -1,17 +1,18 @@
 ---
-import { bannerSlots } from '../data/banners';
+import { bannerSlots, getBannerSlot, type BannerSlotId } from '../data/banners';
 import { buildTrackedLink } from '../utils/links';
 
 interface Props {
-  slotId: keyof typeof bannerSlots;
+  id: BannerSlotId;
   class?: string;
 }
 
-const { slotId, class: className = '' } = Astro.props as Props;
-const slot = bannerSlots[slotId];
+const { id, class: className = '' } = Astro.props as Props;
+const slot = getBannerSlot(id);
 
 if (!slot) {
-  throw new Error(`Banner slot "${slotId}" is not defined in bannerSlots.`);
+  const available = Object.keys(bannerSlots).join(', ');
+  throw new Error(`Banner slot "${id}" is not defined. Available slots: ${available}`);
 }
 
 const href = buildTrackedLink({
@@ -20,14 +21,22 @@ const href = buildTrackedLink({
   camp: slot.camp,
   placeholder: slot.placeholder
 });
+
+const anchorClass = [
+  'banner-slot block overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-3 text-center shadow-glow',
+  className
+]
+  .filter(Boolean)
+  .join(' ');
 ---
-<div class={`banner-slot glass rounded-3xl border border-white/10 bg-white/5 p-3 text-center ${className}`}>
-  <a class="flex h-full w-full items-center justify-center" href={href} target="_blank" rel="noreferrer">
-    <img
-      class="h-auto max-h-64 w-full rounded-2xl object-cover"
-      src={slot.image}
-      alt={slot.alt}
-      loading="lazy"
-    />
-  </a>
-</div>
+<a class={anchorClass} href={href} target="_blank" rel="nofollow sponsored">
+  <img
+    src={slot.image}
+    alt={slot.alt}
+    width={slot.width}
+    height={slot.height}
+    loading="lazy"
+    decoding="async"
+    class="h-auto w-full object-cover"
+  />
+</a>

--- a/src/data/banners.ts
+++ b/src/data/banners.ts
@@ -1,4 +1,4 @@
-type BannerSlotKey =
+export type BannerSlotId =
   | 'home_top_leaderboard'
   | 'home_mid_rectangle'
   | 'home_footer_leaderboard'
@@ -8,80 +8,105 @@ type BannerSlotKey =
   | 'post_inline_rect'
   | 'post_end_strip';
 
-type BannerConfig = {
-  id: BannerSlotKey;
+type BannerCamp = 'home' | 'models' | 'blog';
+
+type BannerSlotConfig = {
+  id: BannerSlotId;
   path: string;
-  camp: string;
+  camp: BannerCamp;
   image: string;
   alt: string;
+  width: number;
+  height: number;
   placeholder: string;
 };
 
-const sharedPlaceholder = 'https://bongacams.com/landing/bcmlp/models';
+const PLACEHOLDER_BASE = 'https://leads.naughtycamspot.com/sponsor';
 
-export const bannerSlots: Record<BannerSlotKey, BannerConfig> = {
+const buildPlaceholderHref = (slot: BannerSlotId, camp: BannerCamp) =>
+  `${PLACEHOLDER_BASE}?slot=${encodeURIComponent(slot)}&camp=${encodeURIComponent(camp)}`;
+
+export const bannerSlots: Record<BannerSlotId, BannerSlotConfig> = {
   home_top_leaderboard: {
     id: 'home_top_leaderboard',
     path: '/go/home-top-leaderboard.php',
     camp: 'home',
-    image: 'https://placehold.co/1200x250/111827/FFE4E1?text=Home+Top+Leaderboard',
-    alt: 'Home top leaderboard takeover',
-    placeholder: sharedPlaceholder
+    image: '/ads/home_top_leaderboard.svg',
+    alt: 'Homepage top leaderboard banner promoting concierge services.',
+    width: 1200,
+    height: 250,
+    placeholder: buildPlaceholderHref('home_top_leaderboard', 'home')
   },
   home_mid_rectangle: {
     id: 'home_mid_rectangle',
     path: '/go/home-mid-rectangle.php',
     camp: 'home',
-    image: 'https://placehold.co/600x500/111827/FFE4E1?text=Home+Mid+Rectangle',
-    alt: 'Home mid rectangle spotlight',
-    placeholder: sharedPlaceholder
+    image: '/ads/home_mid_rectangle.svg',
+    alt: 'Homepage mid-article rectangle banner showcasing VIP guidance.',
+    width: 600,
+    height: 500,
+    placeholder: buildPlaceholderHref('home_mid_rectangle', 'home')
   },
   home_footer_leaderboard: {
     id: 'home_footer_leaderboard',
     path: '/go/home-footer-leaderboard.php',
     camp: 'home',
-    image: 'https://placehold.co/1200x250/111827/FFE4E1?text=Home+Footer+Leaderboard',
-    alt: 'Home footer leaderboard placement',
-    placeholder: sharedPlaceholder
+    image: '/ads/home_footer_leaderboard.svg',
+    alt: 'Homepage footer leaderboard banner inviting sponsorship chats.',
+    width: 1200,
+    height: 250,
+    placeholder: buildPlaceholderHref('home_footer_leaderboard', 'home')
   },
   model_sidebar_tall: {
     id: 'model_sidebar_tall',
     path: '/go/model-sidebar-tall.php',
     camp: 'models',
-    image: 'https://placehold.co/360x720/111827/FFE4E1?text=Model+Sidebar+Tall',
-    alt: 'Model sidebar tall banner',
-    placeholder: sharedPlaceholder
+    image: '/ads/model_sidebar_tall.svg',
+    alt: 'Model profile sidebar tall banner featuring concierge upgrade.',
+    width: 360,
+    height: 720,
+    placeholder: buildPlaceholderHref('model_sidebar_tall', 'models')
   },
   model_mid_rectangle: {
     id: 'model_mid_rectangle',
     path: '/go/model-mid-rectangle.php',
     camp: 'models',
-    image: 'https://placehold.co/600x500/111827/FFE4E1?text=Model+Mid+Rectangle',
-    alt: 'Model mid rectangle banner',
-    placeholder: sharedPlaceholder
+    image: '/ads/model_mid_rectangle.svg',
+    alt: 'Model profile mid-article rectangle banner with runway strategy.',
+    width: 600,
+    height: 500,
+    placeholder: buildPlaceholderHref('model_mid_rectangle', 'models')
   },
   post_top_strip: {
     id: 'post_top_strip',
     path: '/go/post-top-strip.php',
     camp: 'blog',
-    image: 'https://placehold.co/900x150/111827/FFE4E1?text=Post+Top+Strip',
-    alt: 'Blog post top strip banner',
-    placeholder: sharedPlaceholder
+    image: '/ads/post_top_strip.svg',
+    alt: 'Blog post top strip banner announcing concierge campaigns.',
+    width: 900,
+    height: 150,
+    placeholder: buildPlaceholderHref('post_top_strip', 'blog')
   },
   post_inline_rect: {
     id: 'post_inline_rect',
     path: '/go/post-inline-rect.php',
     camp: 'blog',
-    image: 'https://placehold.co/600x400/111827/FFE4E1?text=Post+Inline+Rect',
-    alt: 'Blog post inline rectangle',
-    placeholder: sharedPlaceholder
+    image: '/ads/post_inline_rect.svg',
+    alt: 'Blog post inline rectangle banner highlighting sponsorship offers.',
+    width: 600,
+    height: 400,
+    placeholder: buildPlaceholderHref('post_inline_rect', 'blog')
   },
   post_end_strip: {
     id: 'post_end_strip',
     path: '/go/post-end-strip.php',
     camp: 'blog',
-    image: 'https://placehold.co/900x200/111827/FFE4E1?text=Post+End+Strip',
-    alt: 'Blog post end strip banner',
-    placeholder: sharedPlaceholder
+    image: '/ads/post_end_strip.svg',
+    alt: 'Blog post end strip banner summarizing concierge contact details.',
+    width: 900,
+    height: 200,
+    placeholder: buildPlaceholderHref('post_end_strip', 'blog')
   }
 };
+
+export const getBannerSlot = (id: BannerSlotId) => bannerSlots[id];

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -74,7 +74,7 @@ const { article, related } = Astro.props;
     </div>
 
     <!-- SLOT: post_top_strip -->
-    <BannerSlot slotId="post_top_strip" />
+    <BannerSlot id="post_top_strip" />
 
     <div class="space-y-6 text-base leading-relaxed text-white/70">
       <p class="first-letter:float-left first-letter:mr-4 first-letter:text-6xl first-letter:font-display first-letter:text-rose-gold first-letter:leading-none">
@@ -87,7 +87,7 @@ const { article, related } = Astro.props;
         premium offers. Energy rises when the room feels choreographed, not chaotic.
       </p>
       <!-- SLOT: post_inline_rect -->
-      <BannerSlot slotId="post_inline_rect" />
+      <BannerSlot id="post_inline_rect" />
       <p>
         Once your baseline vibe is dialled in, layer conversion cues. Highlight goals visually in your overlays, coach mods to echo
         them with warmth, and break the fourth wall with personal thank-you moments. Small details—slowing your voice, leaning into
@@ -102,7 +102,7 @@ const { article, related } = Astro.props;
   </article>
 
   <!-- SLOT: post_end_strip -->
-  <BannerSlot slotId="post_end_strip" class="mt-10" />
+  <BannerSlot id="post_end_strip" class="mt-10" />
 
   <!-- SECTION: Related Posts -->
   <section class="space-y-6">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -185,7 +185,7 @@ const jsonLd = {
     </section>
 
   <!-- SLOT: home_top_leaderboard -->
-  <BannerSlot slotId="home_top_leaderboard" class="mt-14" />
+  <BannerSlot id="home_top_leaderboard" class="mt-14" />
 
   <!-- SECTION: Concierge -->
   <section id="concierge" class="space-y-12">
@@ -216,7 +216,7 @@ const jsonLd = {
     </section>
 
   <!-- SLOT: home_mid_rectangle -->
-  <BannerSlot slotId="home_mid_rectangle" class="mt-16" />
+  <BannerSlot id="home_mid_rectangle" class="mt-16" />
 
   <!-- SECTION: Featured Muse -->
   <section id="muse-spotlight" class="glass overflow-hidden rounded-[42px] px-10 py-14">
@@ -339,7 +339,7 @@ const jsonLd = {
     </section>
 
   <!-- SLOT: home_footer_leaderboard -->
-  <BannerSlot slotId="home_footer_leaderboard" class="mt-16" />
+  <BannerSlot id="home_footer_leaderboard" class="mt-16" />
 
   {!pagesBuild && (
     <script is:inline type="module">

--- a/src/pages/models/[slug].astro
+++ b/src/pages/models/[slug].astro
@@ -155,7 +155,7 @@ const platforms = (model.platforms ?? []) as Array<{
           <img src={model.image} alt={model.name} class="h-full w-full object-cover" loading="lazy" />
         </div>
         <!-- SLOT: model_sidebar_tall -->
-        <BannerSlot slotId="model_sidebar_tall" />
+        <BannerSlot id="model_sidebar_tall" />
       </div>
     </div>
   </section>
@@ -197,7 +197,7 @@ const platforms = (model.platforms ?? []) as Array<{
   </section>
 
   <!-- SLOT: model_mid_rectangle -->
-  <BannerSlot slotId="model_mid_rectangle" class="mt-12" />
+  <BannerSlot id="model_mid_rectangle" class="mt-12" />
 
   <!-- SECTION: Gallery -->
   <section class="space-y-8">

--- a/tests/banner-links.test.mjs
+++ b/tests/banner-links.test.mjs
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const loadLinksModule = async (env = {}) => {
+  const keys = Object.keys(env);
+  const previous = {};
+
+  for (const key of keys) {
+    previous[key] = process.env[key];
+    process.env[key] = env[key];
+  }
+
+  const mod = await import(`../src/utils/links.js?seed=${Math.random()}`);
+
+  for (const key of keys) {
+    if (typeof previous[key] === 'undefined') {
+      delete process.env[key];
+    } else {
+      process.env[key] = previous[key];
+    }
+  }
+
+  return mod;
+};
+
+const sample = {
+  path: '/go/sample-offer.php',
+  slot: 'home_top_leaderboard',
+  camp: 'home',
+  placeholder: 'https://leads.naughtycamspot.com/sponsor?slot=home_top_leaderboard&camp=home'
+};
+
+test('Pages builds fall back to safe external links', async () => {
+  const { buildTrackedLink } = await loadLinksModule({ ASTRO_BASE_URL: '/naughtycamspot/' });
+  const href = buildTrackedLink(sample);
+  assert.ok(!href.startsWith('/go/'), 'Pages href must not point to /go/');
+  assert.equal(href, sample.placeholder);
+});
+
+test('Production builds generate tracked /go/ links', async () => {
+  const { buildTrackedLink } = await loadLinksModule({});
+  const href = buildTrackedLink(sample);
+  assert.ok(href.startsWith('/go/'), 'Production href should use /go/ path');
+  assert.ok(href.includes('src=home_top_leaderboard'), 'href must include src param');
+  assert.ok(href.includes('camp=home'), 'href must include camp param');
+});


### PR DESCRIPTION
## Summary
- scaffold reusable `<BannerSlot>` component wired to shared banner config
- add banner slot metadata, placeholder creatives, and placements across home, model, and blog templates
- document slot workflow and add coverage ensuring Pages builds never emit `/go/`

## Testing
- `npm test`

## Pages Preview
- https://leecuevasowner.github.io/naughtycamspot

## Screenshots
- Home: ![Home banners](browser:/invocations/xrspaeku/artifacts/artifacts/home.png)
- Model: ![Model banners](browser:/invocations/xrspaeku/artifacts/artifacts/model.png)
- Post: ![Post banners](browser:/invocations/xrspaeku/artifacts/artifacts/post.png)


------
https://chatgpt.com/codex/tasks/task_e_68f1fa60da0c832685df2733643fec59