### PR TITLE
feat: tracking (Fixes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Luxury gallery frontend for Naughty Cam Spot, built with Astro and Tailwind CSS.
 
 Legacy HTML pages, generators, and blog scaffolding have been removed. Work forward from the Astro surface for new sections and routes.
 
+## Tracked links in prod vs Pages
+
+- Use the shared `buildTrackedLink` helper whenever a `/go/*` slug is involved (homepage hero CTA, `<BannerSlot>`, model profile buttons).
+- Production builds return `/go/*` URLs with `?src=<slot>&camp=<page>&date=YYYYMMDD` appended for tracking.
+- GitHub Pages builds fall back to the provided external placeholder, stripping query strings so previews stay clean and never link to `/go/*`.
+
 ## Banner slots
 
 Banner placement is configured in `src/data/banners.ts`. Each slot defines its `/go/*` path for production, a Pages-safe placeholder link, SVG creative, explicit dimensions, and descriptive alt text.
@@ -39,17 +45,6 @@ SVG placeholders for every slot live in `public/ads/`. Update these assets if cr
 1. Define the slot in `src/data/banners.ts` with a unique `id`, production `/go/*` path, Pages placeholder URL, camp grouping, image path, dimensions, and alt text.
 2. Drop a matching SVG into `public/ads/` so Pages previews have local creative.
 3. Render the slot with `<BannerSlot id="slot_id" />` in the page or layout where it should appear, adding a `<!-- SLOT: slot_id -->` comment for quick scanning.
-
-### Link behaviour
-
-- **Pages builds (`astro.config.pages.mjs`)** use the placeholder URLs from the data file. These must be safe external links and must not start with `/go/` so GitHub Pages previews work.
-- **Production builds** use the `/go/*` slugs and automatically append `?src=<slot>&camp=<page>&date=YYYYMMDD` tracking parameters via the shared `buildTrackedLink` helper.
-
-### Beacons buttons
-
-- Model data objects support an optional `beacons_url` field. When present, model templates render an **All links (Beacons)** button.
-- Pages builds link directly to the external `beacons_url` value so previews never emit `/go/*` paths.
-- Production builds route through `/go/beacons-<slug>` via `buildTrackedLink`, which appends `src=model_page`, `camp=<model>`, and the UTC datestamp for tracking.
 
 ## How to add a model page
 

--- a/src/data/banners.ts
+++ b/src/data/banners.ts
@@ -24,7 +24,7 @@ type BannerSlotConfig = {
 const PLACEHOLDER_BASE = 'https://leads.naughtycamspot.com/sponsor';
 
 const buildPlaceholderHref = (slot: BannerSlotId, camp: BannerCamp) =>
-  `${PLACEHOLDER_BASE}?slot=${encodeURIComponent(slot)}&camp=${encodeURIComponent(camp)}`;
+  `${PLACEHOLDER_BASE}/${camp}/${slot}`;
 
 export const bannerSlots: Record<BannerSlotId, BannerSlotConfig> = {
   home_top_leaderboard: {

--- a/src/utils/links.d.ts
+++ b/src/utils/links.d.ts
@@ -10,4 +10,5 @@ export declare const withBase: (path?: string) => string;
 export declare const buildTrackedLink: (options: BuildTrackedLinkOptions) => string;
 export declare const __test: {
   formatDateStamp: () => string;
+  sanitizePlaceholder: (value: string) => string;
 };

--- a/src/utils/links.js
+++ b/src/utils/links.js
@@ -11,6 +11,22 @@ const envBaseUrl =
 const BASE_URL = runtimeBaseUrl ?? envBaseUrl ?? '/';
 const IS_PAGES_BUILD = BASE_URL !== '/';
 
+const sanitizePlaceholder = (placeholder) => {
+  if (!placeholder) {
+    return '';
+  }
+
+  const trimmed = String(placeholder).trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const withoutHash = trimmed.split('#')[0];
+  const withoutQuery = withoutHash.split('?')[0];
+
+  return withoutQuery;
+};
+
 const formatDateStamp = () => {
   const now = new Date();
   const year = String(now.getUTCFullYear());
@@ -32,7 +48,12 @@ export const withBase = (path = '') => {
 
 export const buildTrackedLink = ({ path, slot, camp, placeholder }) => {
   if (IS_PAGES_BUILD) {
-    return placeholder;
+    const sanitizedPlaceholder = sanitizePlaceholder(placeholder);
+    if (sanitizedPlaceholder && !sanitizedPlaceholder.startsWith('/go/')) {
+      return sanitizedPlaceholder;
+    }
+
+    return 'https://naughtycamspot.com';
   }
 
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
@@ -42,4 +63,4 @@ export const buildTrackedLink = ({ path, slot, camp, placeholder }) => {
   return `${normalizedPath}${queryGlue}${tracking}`;
 };
 
-export const __test = { formatDateStamp };
+export const __test = { formatDateStamp, sanitizePlaceholder };

--- a/tests/banner-links.test.mjs
+++ b/tests/banner-links.test.mjs
@@ -27,14 +27,20 @@ const sample = {
   path: '/go/sample-offer.php',
   slot: 'home_top_leaderboard',
   camp: 'home',
-  placeholder: 'https://leads.naughtycamspot.com/sponsor?slot=home_top_leaderboard&camp=home'
+  placeholder:
+    'https://leads.naughtycamspot.com/sponsor/home/home_top_leaderboard?slot=home_top_leaderboard&camp=home'
 };
 
 test('Pages builds fall back to safe external links', async () => {
   const { buildTrackedLink } = await loadLinksModule({ ASTRO_BASE_URL: '/naughtycamspot/' });
   const href = buildTrackedLink(sample);
   assert.ok(!href.startsWith('/go/'), 'Pages href must not point to /go/');
-  assert.equal(href, sample.placeholder);
+  assert.equal(
+    href,
+    'https://leads.naughtycamspot.com/sponsor/home/home_top_leaderboard',
+    'Pages href should strip query params'
+  );
+  assert.ok(!href.includes('?'), 'Pages href should not contain query params');
 });
 
 test('Production builds generate tracked /go/ links', async () => {

--- a/tests/home-hero-cta.test.mjs
+++ b/tests/home-hero-cta.test.mjs
@@ -42,3 +42,9 @@ test('Production build outputs tracked /go link', async () => {
     `<a href="/go/model-join.php?src=home_hero&camp=home&date=${dateStamp}"></a>`
   );
 });
+
+test('sanitizePlaceholder removes query and hash fragments', async () => {
+  const { __test } = await importLinksWithBase('/docs/');
+  const cleaned = __test.sanitizePlaceholder('https://example.com/join?foo=bar#cta');
+  assert.equal(cleaned, 'https://example.com/join');
+});


### PR DESCRIPTION
Pages: https://leecuevasowner.github.io/naughtycamspot/

## Summary
- sanitize the shared buildTrackedLink helper so Pages builds emit clean external URLs while production keeps /go/* tracking params
- refresh banner slot placeholders, README guidance, and tests to cover hero CTA, BannerSlot, and model affiliate buttons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f269da6c9c832685df7cfd1e72cbb4