### PR TITLE
feat: join-models landing + disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Luxury gallery frontend for Naughty Cam Spot, built with Astro and Tailwind CSS.
 
 - `src/layouts/MainLayout.astro` — shared chrome, fonts, and ambient gradients
 - `src/pages/index.astro` — luxury gallery homepage experience
+- `src/pages/join-models.astro` — recruitment landing with concierge bullets, tracked CTA, FAQ placeholders, and banner slot
+- `src/pages/disclosure.astro` — affiliate disclosure copy surfaced in the global footer
 - `src/styles/tailwind.css` — Tailwind layers plus glassmorphism utility classes
 - `images/` — shared static assets ready to surface in future sections
 
@@ -23,6 +25,13 @@ Legacy HTML pages, generators, and blog scaffolding have been removed. Work forw
 - Production builds return `/go/*` URLs with `?src=<slot>&camp=<page>&date=YYYYMMDD` appended for tracking.
 - GitHub Pages builds fall back to the provided external placeholder, stripping query strings so previews stay clean and never link to `/go/*`.
 - The production server now handles `/go/*` redirects and geotargeted program rotation via the PHP handlers in `public/go/`.
+
+### Join Models CTA behaviour
+
+- The Join Models landing (`src/pages/join-models.astro`) calls `buildTrackedLink` with `/go/model-join.php`, `src=join_models`, and `camp=landing`.
+- Provide a safe public placeholder URL in the `CTA_PLACEHOLDER` constant so Pages builds output an external link that does **not** start with `/go/`.
+- Production builds automatically append the `date=YYYYMMDD` stamp and keep the `/go/model-join.php` target.
+- Update the FAQ copy by editing the `faqItems` array in `src/pages/join-models.astro`.
 
 ## Banner slots
 

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -18,7 +18,8 @@ const navLinks = [
 
 const footerLinks = [
   { href: '/privacy', label: 'Privacy Policy' },
-  { href: '/terms', label: 'Terms' }
+  { href: '/terms', label: 'Terms' },
+  { href: '/disclosure', label: 'Affiliate Disclosure' }
 ];
 
 const mainTopPadding = showNavigation ? 'pt-10' : 'pt-20';

--- a/src/pages/disclosure.astro
+++ b/src/pages/disclosure.astro
@@ -1,0 +1,15 @@
+---
+import MainLayout from '../layouts/MainLayout.astro';
+---
+
+<MainLayout
+  title="Affiliate Disclosure | NaughtyCamSpot"
+  description="Affiliate disclosure for NaughtyCamSpot model recruitment and outbound links."
+>
+  <section class="content-card space-y-4">
+    <h1 class="section-heading">Affiliate Disclosure</h1>
+    <p class="text-sm text-white/70">
+      We use affiliate links for model sign-ups and some outbound links. You pay nothing extra.
+    </p>
+  </section>
+</MainLayout>

--- a/src/pages/join-models.astro
+++ b/src/pages/join-models.astro
@@ -1,0 +1,124 @@
+---
+import BannerSlot from '../components/BannerSlot.astro';
+import MainLayout from '../layouts/MainLayout.astro';
+import { buildTrackedLink, isPagesBuild } from '../utils/links';
+
+const heroBullets = [
+  {
+    title: 'Fast start playbook',
+    description:
+      'Launch rituals, lighting cues, and conversion prompts mapped into a 14-day runway so you can step on set with clarity.'
+  },
+  {
+    title: 'Platform guidance',
+    description:
+      'Account setup audits, compliance walkthroughs, and concierge calibration for Bonga, Chaturbate, CamSoda, and more.'
+  },
+  {
+    title: 'Earnings tracker',
+    description:
+      'Private dashboards tracing nightly performance, tip triggers, and VIP pacing to optimise your growth cadence.'
+  },
+  {
+    title: 'Ongoing support',
+    description:
+      'Mod choreography, aftercare messaging, and strategy debriefs on demand from humans who know the room.'
+  }
+];
+
+const faqItems = [
+  {
+    question: 'How do I start the concierge intake? (Placeholder)',
+    answer: 'We are preparing the intake steps. Expect onboarding choreography notes soon.'
+  },
+  {
+    question: 'Which platforms are supported today? (Placeholder)',
+    answer: 'Full platform roster coming shortly. Submit interest so we can align concierge resources.'
+  },
+  {
+    question: 'What assets are included in the launch kit? (Placeholder)',
+    answer: 'We are finalising the kit contents. Watch this space for specifics on creative, mod scripts, and more.'
+  },
+  {
+    question: 'When will the earnings tracker be available? (Placeholder)',
+    answer: 'Analytics rollout timeline is being set. We will announce as soon as the dashboards are ready.'
+  }
+];
+
+const CTA_PLACEHOLDER = 'https://naughtycamspot.com/models';
+const ctaHref = buildTrackedLink({
+  path: '/go/model-join.php',
+  slot: 'join_models',
+  camp: 'landing',
+  placeholder: CTA_PLACEHOLDER
+});
+const pagesBuild = isPagesBuild();
+---
+
+<MainLayout
+  title="Join Models | NaughtyCamSpot"
+  description="Become a model with NaughtyCamSpot and access concierge playbooks, platform coaching, and real-time revenue insight."
+>
+  <section class="grid gap-12 lg:grid-cols-[1.1fr_0.9fr]">
+    <div class="space-y-8">
+      <div class="space-y-4">
+        <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-5 py-2 text-xs uppercase tracking-[0.4em] text-rose-petal/80">
+          Model Concierge
+        </span>
+        <h1 class="font-display text-5xl leading-tight text-white sm:text-6xl">Become a Model with NCS</h1>
+        <p class="max-w-2xl text-base text-white/70">
+          Submit interest to enter NaughtyCamSpot&apos;s concierge runway. We guide your platform setup, choreograph launch-night rituals, and keep a vigilant eye on earnings so your universe scales with intention.
+        </p>
+      </div>
+      <div class="grid gap-5 sm:grid-cols-2">
+        {heroBullets.map((bullet) => (
+          <div class="content-card space-y-3">
+            <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">{bullet.title}</p>
+            <p class="text-sm text-white/70">{bullet.description}</p>
+          </div>
+        ))}
+      </div>
+      <div>
+        <a
+          data-cta="join-models"
+          class="inline-flex items-center justify-center rounded-full border border-rose-gold/60 bg-rose-gold px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-midnight shadow-glow transition hover:-translate-y-1"
+          href={ctaHref}
+          target="_blank"
+          rel={pagesBuild ? 'noreferrer' : 'nofollow noreferrer'}
+        >
+          Start Concierge Intake
+        </a>
+        <p class="mt-3 text-xs uppercase tracking-[0.3em] text-white/40">
+          {pagesBuild ? 'Opens external concierge briefing' : 'Tracked via /go/model-join.php'}
+        </p>
+      </div>
+    </div>
+    <div class="space-y-6">
+      <div class="content-card space-y-4">
+        <h2 class="section-heading">Concierge Touchpoints</h2>
+        <p class="text-sm text-white/70">
+          Expect warm human support alongside automation. From persona blueprints to nightly recaps, we keep every detail aligned with your boundaries and brand.
+        </p>
+        <p class="text-sm text-white/70">
+          Not ready to commit? Browse our guides, observe the playbooks, and tap the affiliate disclosure to understand how we earn.
+        </p>
+      </div>
+      <BannerSlot id="model_sidebar_tall" class="w-full" />
+    </div>
+  </section>
+
+  <section class="space-y-10">
+    <div class="space-y-4">
+      <h2 class="section-heading">FAQ</h2>
+      <p class="text-sm text-white/60">We are documenting every step. Use these placeholders as a preview of what&apos;s coming soon.</p>
+    </div>
+    <div class="grid gap-6 lg:grid-cols-2">
+      {faqItems.map((item) => (
+        <div class="content-card space-y-3">
+          <h3 class="text-base font-semibold uppercase tracking-[0.25em] text-rose-petal/80">{item.question}</h3>
+          <p class="text-sm text-white/65">{item.answer}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+</MainLayout>

--- a/tests/join-models-cta.test.mjs
+++ b/tests/join-models-cta.test.mjs
@@ -1,0 +1,69 @@
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { rm } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+
+const buildCache = new Map();
+const cleanupDirs = new Set();
+
+const buildJoinModelsPage = async (mode) => {
+  if (buildCache.has(mode)) {
+    return buildCache.get(mode);
+  }
+
+  const outDirName = mode === 'pages' ? 'dist-test-join-pages' : 'dist-test-join-prod';
+  const outDir = path.join(projectRoot, outDirName);
+  await rm(outDir, { recursive: true, force: true });
+
+  const command =
+    mode === 'pages'
+      ? `npx astro build --config astro.config.pages.mjs --outDir ${outDirName}`
+      : `npx astro build --outDir ${outDirName}`;
+
+  execSync(command, { cwd: projectRoot, stdio: 'pipe' });
+
+  cleanupDirs.add(outDir);
+
+  const htmlPath = path.join(outDir, 'join-models', 'index.html');
+  const html = await readFile(htmlPath, 'utf8');
+
+  const result = { html, outDir };
+  buildCache.set(mode, result);
+  return result;
+};
+
+const extractCtaHref = (html) => {
+  const match = html.match(/<a[^>]+data-cta="join-models"[^>]*href="([^"]+)"/i);
+  return match ? match[1] : undefined;
+};
+
+test('Pages build keeps Join Models CTA external', async () => {
+  const { html } = await buildJoinModelsPage('pages');
+  const href = extractCtaHref(html);
+
+  assert.ok(href, 'CTA href should be present');
+  assert.ok(!href.startsWith('/go/'), 'Pages CTA must not start with /go/');
+});
+
+test('Production build uses tracked /go/ link for Join Models CTA', async () => {
+  const { html } = await buildJoinModelsPage('prod');
+  const href = extractCtaHref(html);
+
+  assert.ok(href, 'CTA href should be present');
+  assert.ok(href.startsWith('/go/model-join.php'), 'Prod CTA should use /go/model-join.php');
+  assert.ok(href.includes('src=join_models'), 'Prod CTA should include src=join_models');
+  assert.ok(href.includes('camp=landing'), 'Prod CTA should include camp=landing');
+  assert.ok(href.includes('date='), 'Prod CTA should include date stamp');
+});
+
+after(async () => {
+  for (const dir of cleanupDirs) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add the Join Models landing page with concierge messaging, CTA guardrails, FAQ placeholders, and banner slot
- publish a lightweight affiliate disclosure page and expose the link in the shared footer
- document CTA behaviour and add regression tests for the join-models tracked link

## Testing
- `npm test`

Pages URL: https://leecuevasowner.github.io/naughtycamspot/join-models

Screenshots:
![Join Models landing](browser:/invocations/cskfrtti/artifacts/artifacts/join-models.png)
![Footer Affiliate Disclosure link](browser:/invocations/evzlcgba/artifacts/artifacts/footer-disclosure.png)

------
https://chatgpt.com/codex/tasks/task_e_68f274c0e45c8326a0bbd2147ace0720