### PR TITLE
feat: referral positioning + starter kit

### DIFF
--- a/src/data/banners.ts
+++ b/src/data/banners.ts
@@ -32,7 +32,7 @@ export const bannerSlots: Record<BannerSlotId, BannerSlotConfig> = {
     path: '/go/home-top-leaderboard.php',
     camp: 'home',
     image: '/ads/home_top_leaderboard.svg',
-    alt: 'Homepage top leaderboard banner promoting concierge services.',
+    alt: 'Homepage top leaderboard banner spotlighting starter-kit resources.',
     width: 1200,
     height: 250,
     placeholder: buildPlaceholderHref('home_top_leaderboard', 'home')
@@ -42,7 +42,7 @@ export const bannerSlots: Record<BannerSlotId, BannerSlotConfig> = {
     path: '/go/home-mid-rectangle.php',
     camp: 'home',
     image: '/ads/home_mid_rectangle.svg',
-    alt: 'Homepage mid-article rectangle banner showcasing VIP guidance.',
+    alt: 'Homepage mid-article rectangle banner showcasing starter guidance.',
     width: 600,
     height: 500,
     placeholder: buildPlaceholderHref('home_mid_rectangle', 'home')
@@ -52,7 +52,7 @@ export const bannerSlots: Record<BannerSlotId, BannerSlotConfig> = {
     path: '/go/home-footer-leaderboard.php',
     camp: 'home',
     image: '/ads/home_footer_leaderboard.svg',
-    alt: 'Homepage footer leaderboard banner inviting sponsorship chats.',
+    alt: 'Homepage footer leaderboard banner inviting referral questions.',
     width: 1200,
     height: 250,
     placeholder: buildPlaceholderHref('home_footer_leaderboard', 'home')
@@ -62,7 +62,7 @@ export const bannerSlots: Record<BannerSlotId, BannerSlotConfig> = {
     path: '/go/model-sidebar-tall.php',
     camp: 'models',
     image: '/ads/model_sidebar_tall.svg',
-    alt: 'Model profile sidebar tall banner featuring concierge upgrade.',
+    alt: 'Model profile sidebar tall banner featuring starter kit tips.',
     width: 360,
     height: 720,
     placeholder: buildPlaceholderHref('model_sidebar_tall', 'models')
@@ -72,7 +72,7 @@ export const bannerSlots: Record<BannerSlotId, BannerSlotConfig> = {
     path: '/go/model-mid-rectangle.php',
     camp: 'models',
     image: '/ads/model_mid_rectangle.svg',
-    alt: 'Model profile mid-article rectangle banner with runway strategy.',
+    alt: 'Model profile mid-article rectangle banner with launch strategy.',
     width: 600,
     height: 500,
     placeholder: buildPlaceholderHref('model_mid_rectangle', 'models')
@@ -82,7 +82,7 @@ export const bannerSlots: Record<BannerSlotId, BannerSlotConfig> = {
     path: '/go/post-top-strip.php',
     camp: 'blog',
     image: '/ads/post_top_strip.svg',
-    alt: 'Blog post top strip banner announcing concierge campaigns.',
+    alt: 'Blog post top strip banner announcing referral resources.',
     width: 900,
     height: 150,
     placeholder: buildPlaceholderHref('post_top_strip', 'blog')
@@ -92,7 +92,7 @@ export const bannerSlots: Record<BannerSlotId, BannerSlotConfig> = {
     path: '/go/post-inline-rect.php',
     camp: 'blog',
     image: '/ads/post_inline_rect.svg',
-    alt: 'Blog post inline rectangle banner highlighting sponsorship offers.',
+    alt: 'Blog post inline rectangle banner highlighting starter insights.',
     width: 600,
     height: 400,
     placeholder: buildPlaceholderHref('post_inline_rect', 'blog')
@@ -102,7 +102,7 @@ export const bannerSlots: Record<BannerSlotId, BannerSlotConfig> = {
     path: '/go/post-end-strip.php',
     camp: 'blog',
     image: '/ads/post_end_strip.svg',
-    alt: 'Blog post end strip banner summarizing concierge contact details.',
+    alt: 'Blog post end strip banner summarizing referral contact details.',
     width: 900,
     height: 200,
     placeholder: buildPlaceholderHref('post_end_strip', 'blog')

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -5,7 +5,7 @@ const {
   showNavigation = true
 } = Astro.props;
 import '../styles/tailwind.css';
-import { withBase } from '../utils/links';
+import { buildTrackedLink, withBase } from '../utils/links';
 
 const isPagesBuild = import.meta.env.IS_PAGES === 'true';
 
@@ -36,13 +36,25 @@ const organizationJsonLd = {
   url: import.meta.env.SITE ?? 'https://naughtycamspot.com'
 };
 
+const HERO_CTA_PLACEHOLDER = 'https://linktr.ee/naughtycamspot';
+const navCtaSlot = 'nav_cta';
+const navCtaCamp = 'site_nav';
+
+const navCtaHref = buildTrackedLink({
+  path: '/go/model-join.php',
+  slot: navCtaSlot,
+  camp: navCtaCamp,
+  placeholder: HERO_CTA_PLACEHOLDER
+});
+
 const navLinks = [
   { href: '/', label: 'Home' },
-  { href: '/models', label: 'Models' },
-  { href: '/join', label: 'Become a Model' },
+  { href: '/starter-kit', label: 'Starter Kit' },
+  { href: '/join', label: 'Join' },
   { href: '/blog', label: 'Blog' },
   { href: '/about', label: 'About' },
-  { href: '/contact', label: 'Contact' }
+  { href: '/contact', label: 'Contact' },
+  { href: '/models/anna-prince', label: 'Example model page' }
 ];
 
 const footerLinks = [
@@ -100,11 +112,14 @@ gtag('config', '${gaMeasurementId}');`}
             </a>
             <a
               class="rounded-full border border-rose-gold/40 bg-rose-gold/20 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-petal shadow-glow backdrop-blur-xl transition hover:border-rose-gold/60 hover:bg-rose-gold/30"
-              href="https://chaturbate.com/in/?tour=NwNd&campaign=YIOhf&track=default"
+              href={navCtaHref}
               target="_blank"
               rel="noreferrer"
+              data-track={shouldTrackClicks ? 'click' : undefined}
+              data-slot={shouldTrackClicks ? navCtaSlot : undefined}
+              data-camp={shouldTrackClicks ? navCtaCamp : undefined}
             >
-              Request VIP
+              Start camming • Free starter kit
             </a>
           </div>
           <nav class="flex w-full flex-wrap items-center justify-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-3 text-[0.65rem] uppercase tracking-[0.25em] text-white/70 backdrop-blur-2xl sm:gap-4 sm:text-[0.7rem] sm:tracking-[0.28em] lg:flex-nowrap lg:text-sm lg:tracking-[0.3em]">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -54,9 +54,8 @@ import MainLayout from '../layouts/MainLayout.astro';
   <section class="content-card space-y-4">
     <h2 class="section-heading">Founder Note</h2>
     <p class="text-sm text-white/70">
-      "We built NaughtyCamSpot to be the agency we wished existed when we started. Our models aren't just performers; they're
-      entrepreneurs with signature brands. We simply provide the infrastructure, the storytelling, and the protection to help them
-      grow without burning out." -- Lola Cuevas, Founder
+      "We built NaughtyCamSpot to be the referral resource we wished existed when we started. Models stay independent owners—we
+      just hand them better tools, guidance, and documentation so they can grow without burning out." -- Lola Cuevas, Founder
     </p>
   </section>
 </MainLayout>

--- a/src/pages/disclosure.astro
+++ b/src/pages/disclosure.astro
@@ -6,10 +6,21 @@ import MainLayout from '../layouts/MainLayout.astro';
   title="Affiliate Disclosure | NaughtyCamSpot"
   description="Affiliate disclosure for NaughtyCamSpot model recruitment and outbound links."
 >
-  <section class="content-card space-y-4">
+  <section class="content-card space-y-4 text-sm text-white/70">
     <h1 class="section-heading">Affiliate Disclosure</h1>
-    <p class="text-sm text-white/70">
-      We use affiliate links for model sign-ups and some outbound links. You pay nothing extra.
+    <p>
+      NaughtyCamSpot operates as a referral hub. When you click a link and join a paid cam program, we may earn affiliate
+      commissions. Those commissions fund the free 14-day starter kit you receive after verifying your signup.
+    </p>
+    <ul class="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-5 backdrop-blur-xl text-xs uppercase tracking-[0.3em] text-white/55">
+      <li>No employment or agency relationship.</li>
+      <li>No guarantee of earnings.</li>
+      <li>Accounts remain yours; you can leave anytime.</li>
+      <li>Affiliate links fund the starter kit.</li>
+    </ul>
+    <p>
+      We do not manage, represent, or promote talent. All content on this site is educational or illustrative. If you have
+      questions about this disclosure, contact <a class="text-rose-gold underline-offset-4 hover:underline" href="mailto:concierge@naughtycamspot.com">concierge@naughtycamspot.com</a>.
     </p>
   </section>
 </MainLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -63,16 +63,16 @@ const featuredMuse = featuredMuseEntry
       name: featuredMuseEntry.data.name,
       archetype: featuredMuseEntry.data.archetype,
       image: featuredMuseEntry.data.heroImage,
-      quote: `“Every room ${featuredMuseEntry.data.name} builds feels like a gallery opening. My fans stay longer, tip deeper, and leave with a story to tell.”`,
-      story: `${featuredMuseEntry.data.name} anchors our concierge roster with luxe rituals, rotating set design, and segmented aftercare. From VIP salons to livestream premieres, they execute every beat with polish.`,
+      quote: `${featuredMuseEntry.data.name}'s walkthrough shows how we format storytelling, offers, and lighting notes inside the starter kit.`,
+      story: `${featuredMuseEntry.data.name} lives in our example library so you can see how a polished bio, visuals, and schedule might flow. Use it as inspiration—your accounts stay yours, and nothing here is a promise of promotion.`,
       ctaHref: `/models/${featuredMuseEntry.id}`
     }
   : {
       name: 'Coming Soon',
-      archetype: 'Signature muse',
+      archetype: 'Example muse',
       image: 'https://images.unsplash.com/photo-1517841905240-472988babdf9?auto=format&fit=crop&w=960&q=80',
-      quote: '“Every room they build feels like a gallery opening. My fans stay longer, tip deeper, and leave with a story to tell.”',
-      story: 'Our next concierge muse is being curated. Check back shortly for a fresh spotlight.',
+      quote: 'This placeholder illustrates how we storyboard the starter kit resources you’ll receive after sign-up.',
+      story: 'We’re drafting additional example pages to showcase kit tactics. Check back for fresh demos you can borrow from immediately.',
       ctaHref: '/models'
     };
 
@@ -158,14 +158,14 @@ const websiteJsonLd = {
       <div class="relative grid gap-14 lg:grid-cols-[1.1fr_0.9fr]">
         <div class="space-y-8">
           <p class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-5 py-2 text-xs uppercase tracking-[0.4em] text-rose-petal/80">
-            Elevated model gallery
+            Referral starter kit hub
           </p>
           <h1 class="font-display text-5xl leading-tight text-white sm:text-6xl">
-            The luxury runway<br />for models who own the night
+            Sign up with our links → get a free 14-day starter kit
           </h1>
           <p class="max-w-xl text-lg text-white/70">
-            Curated aesthetics, glassy ambience, and concierge-level support. NaughtyCamSpot transforms your room into an
-            immersive world that seduces premium fans and keeps them close.
+            We’re a referral collective—no management, no promo promises. Use our affiliate links, send proof, and you’ll
+            instantly receive tools, schedules, and scripts to launch faster while keeping full control of your accounts.
           </p>
           <div class="flex flex-col gap-4 sm:flex-row">
             <a
@@ -177,13 +177,13 @@ const websiteJsonLd = {
               data-slot={shouldTrackClicks ? heroCtaSlot : undefined}
               data-camp={shouldTrackClicks ? heroCtaCamp : undefined}
             >
-              Become Our Next Muse
+              Start camming • Free starter kit
             </a>
             <a
               class="flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-6 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-white/80 backdrop-blur-xl transition hover:-translate-y-1"
-              href="#concierge"
+              href={withBase('/join')}
             >
-              Explore the VIP Suite
+              See how it works
             </a>
           </div>
         </div>
@@ -209,13 +209,13 @@ const websiteJsonLd = {
   <section aria-labelledby="featured-muses-heading" class="mt-14">
       <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h2 id="featured-muses-heading" class="font-display text-3xl text-white sm:text-4xl">Featured muses</h2>
+          <h2 id="featured-muses-heading" class="font-display text-3xl text-white sm:text-4xl">Example builds</h2>
           <p class="mt-2 text-sm text-white/70">
-            Spotlighting concierge muses you can study, book, or draw inspiration from for your own runway.
+            These sample profiles exist to demonstrate structure and storytelling. Study them as templates—no promotion or booking implied.
           </p>
         </div>
         <a class="text-xs uppercase tracking-[0.35em] text-rose-gold transition hover:text-white" href={withBase('/models')}>
-          View gallery →
+          View example gallery →
         </a>
       </div>
       <div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -231,7 +231,7 @@ const websiteJsonLd = {
             ></div>
             <div class="relative space-y-2">
               <span class="inline-flex items-center gap-2 rounded-full border border-white/15 bg-black/40 px-4 py-1 text-[0.65rem] uppercase tracking-[0.4em] text-rose-petal/70">
-                Concierge muse
+                Example model
               </span>
               <h3 class="font-display text-2xl text-white">{tile.name}</h3>
               <p class="text-sm uppercase tracking-[0.3em] text-white/70">{tile.role}</p>

--- a/src/pages/join.astro
+++ b/src/pages/join.astro
@@ -1,96 +1,183 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
+import { buildTrackedLink, withBase } from '../utils/links';
 
-const benefits = [
-  'Concierge onboarding rituals tailored to your persona',
-  'AI-assisted fan segmentation and nightly performance recaps',
-  'Dedicated mod team choreography and boundary-respecting monetization',
-  'Luxury branding assets, photoshoot direction, and bio engineering'
+const HERO_CTA_PLACEHOLDER = 'https://linktr.ee/naughtycamspot';
+const joinSlot = 'join_page';
+const joinCamp = 'join';
+
+const joinHref = buildTrackedLink({
+  path: '/go/model-join.php',
+  slot: joinSlot,
+  camp: joinCamp,
+  placeholder: HERO_CTA_PLACEHOLDER
+});
+
+const resolveHostname = (value: string | undefined) => {
+  if (!value) {
+    return '';
+  }
+
+  try {
+    return new URL(value).hostname;
+  } catch {
+    return String(value).replace(/^https?:\/\//, '').split('/')[0];
+  }
+};
+
+const siteHostname = resolveHostname(import.meta.env.SITE ?? '');
+const isPagesBuild = import.meta.env.IS_PAGES === 'true';
+const shouldTrackClicks = siteHostname === 'naughtycamspot.com' && !isPagesBuild;
+
+const howItWorks = [
+  {
+    title: 'Click join',
+    detail:
+      'Tap the join button to open our affiliate rotator. Pick a paid cam program and complete their sign-up flow using our link.'
+  },
+  {
+    title: 'Send proof',
+    detail:
+      'Email a screenshot or your referral code to concierge@naughtycamspot.com so we can confirm the referral credit.'
+  },
+  {
+    title: 'Receive the starter kit',
+    detail:
+      'We immediately send the 14-day launch kit: lighting checklist, scripted opener, tip menu, pricing ladders, schedule, and ToS cheatsheet.'
+  },
+  {
+    title: 'Optional Q&A',
+    detail:
+      'Need clarification? Reply to the starter-kit email for asynchronous guidance—no hands-on promotion, just answers.'
+  }
 ];
 
-const steps = [
-  'Apply with your preferred platform and baseline experience',
-  'Meet your concierge strategist to map the launch runway',
-  'Activate premium show formats with real-time coaching',
-  'Scale your patron ecosystem with our affiliate partners'
+const starterKitItems = [
+  'Lighting checklist for webcams and phones',
+  'Opening show script with icebreakers',
+  'Tip menu with upsell ladders',
+  '14-day launch schedule with daily prompts',
+  'Pricing ladders for tokens, tributes, and bundles',
+  'Terms of service cheatsheet with quick references'
+];
+
+const whatWereNot = [
+  'Not an agency, manager, or representative',
+  'No paid promotions or social boosts promised',
+  'We never take a cut—affiliate links fund the starter kit',
+  'You own every account and can leave whenever you like'
+];
+
+const faq = [
+  {
+    question: 'Who owns the accounts?',
+    answer:
+      'You do. Every platform profile stays under your control. We only provide starter resources after you sign up with our links.'
+  },
+  {
+    question: 'Do you guarantee earnings?',
+    answer:
+      'No. Results depend on your effort, platform policies, and audience. The starter kit is a guide—not a promise of income.'
+  },
+  {
+    question: 'Is this employment or an agency contract?',
+    answer:
+      'No. There is no employment, representation, or agency relationship. We run an affiliate-funded resource hub.'
+  },
+  {
+    question: 'What happens after the starter kit?',
+    answer:
+      'You can email follow-up questions, share your first payout, and, if you like, provide a one-line testimonial so other models know what to expect.'
+  }
 ];
 ---
 
 <MainLayout
   title="Join | NaughtyCamSpot"
-  description="Become a NaughtyCamSpot model and unlock concierge growth, luxury branding, and premium fan conversion systems."
+  description="Sign up through NaughtyCamSpot affiliate links to unlock the free 14-day cam model starter kit."
 >
   <section class="hero-shell parallax-veil">
     <div class="pointer-events-none absolute inset-0 bg-gradient-to-b from-white/10 via-transparent to-black/60"></div>
     <div class="relative space-y-6">
-      <span class="hero-tagline">Model Recruitment</span>
-      <h1 class="font-display text-5xl leading-tight text-white sm:text-6xl">Become a Model with NaughtyCamSpot</h1>
+      <span class="hero-tagline">Referral starter kit</span>
+      <h1 class="font-display text-5xl leading-tight text-white sm:text-6xl">Start camming, keep control, claim your kit</h1>
       <p class="max-w-2xl text-base text-white/70">
-        Join our growing network of models earning more through smart promotion, refined ambience, and data-guided strategy. We pair
-        human concierge insight with automation to elevate your room into an unforgettable luxury experience.
+        NaughtyCamSpot is a referral + starter-kit hub. Click join, finish the partner program signup with our links, send proof,
+        and we email the full 14-day launch kit—no promo promises, no management fees.
       </p>
       <a
         class="inline-flex w-fit items-center justify-center rounded-full border border-rose-gold/60 bg-rose-gold px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-midnight shadow-glow transition hover:-translate-y-1"
-        href="mailto:concierge@naughtycamspot.com"
+        href={joinHref}
+        target="_blank"
+        rel="noreferrer"
+        data-track={shouldTrackClicks ? 'click' : undefined}
+        data-slot={shouldTrackClicks ? joinSlot : undefined}
+        data-camp={shouldTrackClicks ? joinCamp : undefined}
       >
-        Apply Now
+        Start camming • Free starter kit
       </a>
     </div>
   </section>
 
-  <section class="grid gap-10 lg:grid-cols-2">
-    <article class="content-card space-y-6">
-      <div>
-        <h2 class="section-heading">Why models choose us</h2>
-        <p class="mt-4 text-sm text-white/70">
-          Our concierge team orchestrates launch timelines, brand positioning, and mod choreography so you can focus on performance.
-          Every detail from lighting to call-to-action copy is tuned for premium audiences ready to invest.
-        </p>
-      </div>
-      <ul class="grid gap-4 text-sm text-white/70">
-        {benefits.map((benefit) => (
-          <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">{benefit}</li>
-        ))}
-      </ul>
-    </article>
-    <article class="content-card space-y-6">
-      <div>
-        <h2 class="section-heading">How onboarding works</h2>
-        <p class="mt-4 text-sm text-white/70">
-          We keep the runway elegant and efficient. Expect warm guidance, VIP resources, and purposeful milestones from sign-up to
-          your first signature show.
-        </p>
-      </div>
-      <ol class="grid gap-4 text-sm text-white/70">
-        {steps.map((step, index) => (
-          <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">
-            <span class="text-xs uppercase tracking-[0.3em] text-rose-petal/70">Step {index + 1}</span>
-            <p class="mt-2">{step}</p>
-          </li>
-        ))}
-      </ol>
-    </article>
+  <section class="content-card space-y-6">
+    <h2 class="section-heading">How it works</h2>
+    <p class="text-sm text-white/70">
+      Four simple steps keep the process transparent. The full breakdown lives in our
+      <a class="text-rose-gold underline-offset-4 hover:underline" href={withBase('/starter-kit')}>starter kit overview</a>
+      so you always know what’s included.
+    </p>
+    <ol class="grid gap-4 text-sm text-white/70 sm:grid-cols-2">
+      {howItWorks.map((step, index) => (
+        <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">
+          <span class="text-xs uppercase tracking-[0.3em] text-rose-petal/70">Step {index + 1}</span>
+          <p class="mt-2 font-semibold text-white">{step.title}</p>
+          <p class="mt-1 text-white/70">{step.detail}</p>
+        </li>
+      ))}
+    </ol>
   </section>
 
-  <section class="space-y-8">
-    <h2 class="section-heading">What you receive</h2>
-    <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-      <div class="content-card space-y-3">
-        <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Brand Systems</p>
-        <p class="text-sm text-white/70">Moodboards, bio copy, and signature room experiences that attract premium fans.</p>
-      </div>
-      <div class="content-card space-y-3">
-        <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Growth Data</p>
-        <p class="text-sm text-white/70">Dashboards illuminating tip cadence, VIP segments, and high-converting moments.</p>
-      </div>
-      <div class="content-card space-y-3">
-        <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Community</p>
-        <p class="text-sm text-white/70">Private mastermind rooms, nightly debriefs, and a vetted mod collective.</p>
-      </div>
-      <div class="content-card space-y-3">
-        <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Affiliate Engine</p>
-        <p class="text-sm text-white/70">Partnerships with CamSoda, Chaturbate, and premier networks to widen your reach.</p>
-      </div>
-    </div>
+  <section class="content-card space-y-6">
+    <h2 class="section-heading">What you get</h2>
+    <p class="text-sm text-white/70">
+      Everything arrives in one email bundle immediately after we verify your referral. Download, duplicate, and adapt every
+      worksheet for your own brand.
+    </p>
+    <ul class="grid gap-4 text-sm text-white/70 sm:grid-cols-2">
+      {starterKitItems.map((item) => (
+        <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">{item}</li>
+      ))}
+    </ul>
+  </section>
+
+  <section class="content-card space-y-6">
+    <h2 class="section-heading">What we’re not</h2>
+    <p class="text-sm text-white/70">
+      Clarity first. We only provide tools, templates, and email support. There is no management or promotion component.
+    </p>
+    <ul class="grid gap-4 text-sm text-white/70">
+      {whatWereNot.map((item) => (
+        <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">{item}</li>
+      ))}
+    </ul>
+  </section>
+
+  <section class="content-card space-y-6">
+    <h2 class="section-heading">FAQ</h2>
+    <dl class="grid gap-4 text-sm text-white/70">
+      {faq.map((item) => (
+        <div class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">
+          <dt class="text-xs uppercase tracking-[0.3em] text-rose-petal/70">{item.question}</dt>
+          <dd class="mt-2 text-white/70">{item.answer}</dd>
+        </div>
+      ))}
+    </dl>
+  </section>
+
+  <section class="content-card space-y-4 text-xs uppercase tracking-[0.3em] text-white/55">
+    <p>No employment or agency relationship.</p>
+    <p>No guarantee of earnings.</p>
+    <p>Accounts remain yours; you can leave anytime.</p>
+    <p>Affiliate links fund the starter kit.</p>
   </section>
 </MainLayout>

--- a/src/pages/models.astro
+++ b/src/pages/models.astro
@@ -3,7 +3,7 @@ import MainLayout from '../layouts/MainLayout.astro';
 import { withBase } from '../utils/links';
 import { getCollection } from 'astro:content';
 
-const categories = ['Featured', 'New', 'Trending', 'VR'];
+const categories = ['Lighting', 'Conversion', 'Scheduling', 'Aftercare'];
 
 const modelEntries = await getCollection('models');
 const models = modelEntries
@@ -27,18 +27,18 @@ const models = modelEntries
 ---
 
 <MainLayout
-  title="Models | NaughtyCamSpot"
-  description="Explore the NaughtyCamSpot model gallery — a curated roster of performers with concierge-level positioning."
+  title="Example Models | NaughtyCamSpot"
+  description="Explore example cam model pages that demonstrate how to use the NaughtyCamSpot starter kit templates."
 >
   <!-- SECTION: Models Hero -->
   <section class="hero-shell parallax-veil">
     <div class="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-black/50"></div>
     <div class="relative space-y-6">
-      <span class="hero-tagline">Signature Roster</span>
-      <h1 class="font-display text-5xl leading-tight text-white sm:text-6xl">Meet Our Featured Models</h1>
+      <span class="hero-tagline">Example Library</span>
+      <h1 class="font-display text-5xl leading-tight text-white sm:text-6xl">Example model walkthroughs</h1>
       <p class="max-w-2xl text-base text-white/70">
-        A living gallery of muses crafted with bespoke branding, concierge coaching, and compelling conversion frameworks. Tap in to
-        preview their rooms and study how luxury-focused storytelling converts fans into patrons.
+        These pages are demos, not promotions. Each example highlights how to apply the starter kit’s lighting notes, schedule, and
+        conversion ladders. Use them as inspiration while keeping full control of your own accounts.
       </p>
     </div>
   </section>
@@ -78,7 +78,7 @@ const models = modelEntries
               class="inline-flex items-center gap-2 text-xs uppercase tracking-[0.35em] text-rose-petal transition hover:text-rose-gold"
               href={withBase(`/models/${model.slug}`)}
             >
-              View profile ↗
+              View example ↗
             </a>
           </div>
         </article>

--- a/src/pages/models/[slug].astro
+++ b/src/pages/models/[slug].astro
@@ -110,13 +110,16 @@ const relatedCards = related.map((entry) => ({
     <div class="grid gap-12 lg:grid-cols-[1.15fr_0.85fr]">
       <div class="space-y-6">
         <span class="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.4em] text-rose-petal/80">
-          Model profile
+          Example model page
         </span>
         <div class="space-y-4">
           <h1 class="font-display text-5xl text-white sm:text-6xl">{data.name}</h1>
           <p class="text-sm uppercase tracking-[0.3em] text-rose-petal/80">{data.archetype}</p>
           <p class="max-w-2xl text-base leading-relaxed text-white/70">
             {data.summary}
+          </p>
+          <p class="text-xs uppercase tracking-[0.3em] text-white/55">
+            Demo only • No promotion or representation. Use this layout to craft your own profile once you claim the starter kit.
           </p>
         </div>
         <div class="space-y-3">

--- a/src/pages/starter-kit.astro
+++ b/src/pages/starter-kit.astro
@@ -1,0 +1,45 @@
+---
+import MainLayout from '../layouts/MainLayout.astro';
+---
+
+<MainLayout
+  title="Starter Kit | NaughtyCamSpot"
+  description="Preview the free 14-day cam model starter kit you receive after signing up through NaughtyCamSpot affiliate links."
+>
+  <section class="content-card space-y-6">
+    <span class="hero-tagline">Starter kit preview</span>
+    <h1 class="section-heading">Inside the free 14-day launch kit</h1>
+    <p class="text-sm text-white/70">
+      This page is a placeholder overview. After you verify your signup through our links, we email the complete bundle with downloadable files and editable templates.
+    </p>
+  </section>
+
+  <section class="content-card space-y-4">
+    <h2 class="section-heading">What ships immediately</h2>
+    <ul class="grid gap-4 text-sm text-white/70 sm:grid-cols-2">
+      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Lighting checklist (home studio + travel)</li>
+      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Show script with 3 opening variations</li>
+      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Tip menu + upsell ladder matrix</li>
+      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">14-day schedule with daily focus prompts</li>
+      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Pricing ladder for tokens, tributes, and bundles</li>
+      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Terms of service cheatsheet with fast references</li>
+    </ul>
+  </section>
+
+  <section class="content-card space-y-4 text-sm text-white/70">
+    <h2 class="section-heading">How to unlock it</h2>
+    <ol class="grid gap-4 sm:grid-cols-2">
+      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Join a paid platform through our affiliate rotator.</li>
+      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Send proof via screenshot or referral code.</li>
+      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Receive the starter kit email bundle instantly.</li>
+      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Ask follow-up questions any time during the 14-day runway.</li>
+    </ol>
+  </section>
+
+  <section class="content-card space-y-4 text-xs uppercase tracking-[0.3em] text-white/55">
+    <p>No employment or agency relationship.</p>
+    <p>No guarantee of earnings.</p>
+    <p>Accounts remain yours; you can leave anytime.</p>
+    <p>Affiliate links fund the starter kit.</p>
+  </section>
+</MainLayout>


### PR DESCRIPTION
## Summary
- reposition the homepage hero and navigation around the referral-powered starter kit offer
- rebuild the join flow copy with "how it works," starter kit details, legal disclosures, and a new starter-kit stub page
- refresh supporting pages (disclosure, models, example profile, banners) to remove promotion language and highlight example-only context

## Testing
- `npm test`

Pages preview: (local environment)

Screenshots:
- Hero: _(pending – captured once deployed)_
- Join: _(pending – captured once deployed)_
- Disclosure footer: _(pending – captured once deployed)_
- Anna example badge: _(pending – captured once deployed)_
- Starter kit stub: _(pending – captured once deployed)_

------
https://chatgpt.com/codex/tasks/task_e_68f289a0b0f88326933e2cd1db5c0daa