### PR TITLE
feat: claim flow + starter kit delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 dist/
 .astro/
+public/claim/claims.log

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ Legacy HTML pages, generators, and blog scaffolding have been removed. Work forw
 - Production builds automatically append the `date=YYYYMMDD` stamp and keep the `/go/model-join.php` target.
 - Update the FAQ copy by editing the `faqItems` array in `src/pages/join-models.astro`.
 
+## Starter kit claim flow
+
+- The Pages-safe instructions live in `src/pages/claim.astro`. It renders the proof checklist and links to the correct claim endpoint depending on the build (Tally on Pages, `/claim/` on ViceTemple) using the shared `getClaimUrl` helper.
+- ViceTemple serves the multipart form from `public/claim/index.php`. Proof uploads are written to `public/claim/uploads/<year>/<month>/` and each submission is appended to `public/claim/claims.log`.
+- Notification emails go to `admin@naughtycamspot.com` through PHP&apos;s native `mail()` function. Confirm that the host has outbound email enabled so concierge receives alerts.
+- Adjust the external intake URL by editing `CLAIM_FORM_EXTERNAL_URL` in `src/utils/links.js`. Production automatically switches back to `/claim/`.
+- `.htaccess` hardens the claim folder: requests are limited to `GET`/`POST` and executable extensions inside `uploads/` are denied. Keep those guards intact when extending the flow.
+- Privacy reminder: claims store the submitter&apos;s name, email, platform selection, optional notes, and the uploaded screenshot. Treat the uploads directory and log file as sensitive customer data and restrict server-level access accordingly.
+
 ## Banner slots
 
 Banner placement is configured in `src/data/banners.ts`. Each slot defines its `/go/*` path for production, a Pages-safe placeholder link, SVG creative, explicit dimensions, and descriptive alt text.

--- a/public/claim/.htaccess
+++ b/public/claim/.htaccess
@@ -1,0 +1,17 @@
+<IfModule mod_authz_core.c>
+  <LimitExcept GET POST>
+    Require all denied
+  </LimitExcept>
+</IfModule>
+<IfModule !mod_authz_core.c>
+  <LimitExcept GET POST>
+    Deny from all
+  </LimitExcept>
+</IfModule>
+
+Options -ExecCGI
+
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteRule ^uploads/.*\.(?:php|phtml|phar|cgi|pl|py|rb|sh)$ - [F,L]
+</IfModule>

--- a/public/claim/index.php
+++ b/public/claim/index.php
@@ -1,0 +1,546 @@
+<?php
+
+declare(strict_types=1);
+
+$platformOptions = [
+    'bonga' => 'Bonga',
+    'camsoda' => 'CamSoda',
+    'chaturbate' => 'Chaturbate',
+    'other' => 'Other',
+];
+
+$maxUploadBytes = 5 * 1024 * 1024; // 5 MB
+$mimeToExtension = [
+    'image/png' => 'png',
+    'image/jpeg' => 'jpg',
+];
+
+$values = [
+    'name' => '',
+    'email' => '',
+    'platform' => '',
+    'notes' => '',
+    'src' => request_string('src'),
+    'camp' => request_string('camp'),
+    'date' => request_string('date'),
+];
+$errors = [];
+$uploadMeta = null;
+
+if (request_method_is('POST')) {
+    $values['name'] = sanitize_text($_POST['name'] ?? '', 200);
+    $values['email'] = sanitize_text($_POST['email'] ?? '', 200);
+    $values['platform'] = sanitize_text($_POST['platform'] ?? '', 20);
+    $values['notes'] = sanitize_multiline($_POST['notes'] ?? '', 4000);
+    $values['src'] = sanitize_tracking($_POST['src'] ?? $values['src']);
+    $values['camp'] = sanitize_tracking($_POST['camp'] ?? $values['camp']);
+    $values['date'] = sanitize_tracking($_POST['date'] ?? $values['date']);
+
+    if ($values['name'] === '') {
+        $errors['name'] = 'Please enter your name so we know who submitted the claim.';
+    }
+
+    if ($values['email'] === '' || filter_var($values['email'], FILTER_VALIDATE_EMAIL) === false) {
+        $errors['email'] = 'Please provide a valid email address so we can deliver the kit.';
+    }
+
+    if (!array_key_exists($values['platform'], $platformOptions)) {
+        $errors['platform'] = 'Select the cam platform you just joined.';
+    }
+
+    $file = $_FILES['signup_screenshot'] ?? null;
+    if (!is_array($file) || !array_key_exists('error', $file)) {
+        $errors['signup_screenshot'] = 'Please upload your signup screenshot.';
+    } else {
+        $fileError = (int) $file['error'];
+        if ($fileError === UPLOAD_ERR_NO_FILE) {
+            $errors['signup_screenshot'] = 'Please upload your signup screenshot.';
+        } elseif ($fileError === UPLOAD_ERR_INI_SIZE || $fileError === UPLOAD_ERR_FORM_SIZE) {
+            $errors['signup_screenshot'] = 'The screenshot is larger than 5 MB. Please upload a smaller image.';
+        } elseif ($fileError === UPLOAD_ERR_PARTIAL) {
+            $errors['signup_screenshot'] = 'The screenshot upload did not finish. Please try again.';
+        } elseif ($fileError !== UPLOAD_ERR_OK) {
+            $errors['signup_screenshot'] = 'We could not process the upload. Please try again.';
+        } else {
+            $fileSize = isset($file['size']) ? (int) $file['size'] : 0;
+            if ($fileSize <= 0) {
+                $errors['signup_screenshot'] = 'We could not read the screenshot. Please try again.';
+            } elseif ($fileSize > $maxUploadBytes) {
+                $errors['signup_screenshot'] = 'The screenshot is larger than 5 MB. Please upload a smaller image.';
+            } elseif (!isset($file['tmp_name']) || !is_uploaded_file($file['tmp_name'])) {
+                $errors['signup_screenshot'] = 'We could not verify the upload. Please try again.';
+            } else {
+                $mimeType = detect_mime_type($file['tmp_name']);
+                if ($mimeType === '' || !array_key_exists($mimeType, $mimeToExtension)) {
+                    $errors['signup_screenshot'] = 'Please upload a PNG or JPG image.';
+                } else {
+                    $uploadMeta = [
+                        'tmp_name' => $file['tmp_name'],
+                        'mime' => $mimeType,
+                        'extension' => $mimeToExtension[$mimeType],
+                        'size' => $fileSize,
+                        'original_name' => (string) ($file['name'] ?? ''),
+                    ];
+                }
+            }
+        }
+    }
+
+    if (empty($errors)) {
+        $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $year = $now->format('Y');
+        $month = $now->format('m');
+        $uploadDirectory = __DIR__ . '/uploads/' . $year . '/' . $month;
+
+        if (!is_dir($uploadDirectory) && !mkdir($uploadDirectory, 0755, true) && !is_dir($uploadDirectory)) {
+            $errors['general'] = 'We could not store your upload right now. Please try again later or email concierge@naughtycamspot.com.';
+        } else {
+            $randomBytes = bin2hex(random_bytes(16));
+            $filename = $randomBytes . '.' . $uploadMeta['extension'];
+            $destination = $uploadDirectory . '/' . $filename;
+
+            if (!move_uploaded_file($uploadMeta['tmp_name'], $destination)) {
+                $errors['general'] = 'We could not save your upload. Please try again.';
+            } else {
+                @chmod($destination, 0644);
+                $relativePath = 'uploads/' . $year . '/' . $month . '/' . $filename;
+
+                $logEntry = build_log_entry($now, $relativePath, $values, $uploadMeta, $platformOptions);
+                $logPath = __DIR__ . '/claims.log';
+                if ($logEntry === '' || file_put_contents($logPath, $logEntry . PHP_EOL, FILE_APPEND | LOCK_EX) === false) {
+                    $errors['general'] = 'We saved your upload but could not log the claim. Please contact concierge@naughtycamspot.com.';
+                    @unlink($destination);
+                } else {
+                    $platformLabel = $platformOptions[$values['platform']];
+                    $subject = 'NCS Claim: ' . $platformLabel;
+                    $emailBody = build_email_body($now, $relativePath, $values, $platformLabel);
+                    $headers = [
+                        'MIME-Version: 1.0',
+                        'Content-Type: text/plain; charset=UTF-8',
+                        'From: NaughtyCamSpot <no-reply@naughtycamspot.com>',
+                    ];
+                    if ($values['email'] !== '') {
+                        $headers[] = 'Reply-To: ' . $values['email'];
+                    }
+
+                    @mail('admin@naughtycamspot.com', $subject, $emailBody, implode("\r\n", $headers));
+
+                    header('Location: /claim/success.html', true, 302);
+                    exit;
+                }
+            }
+        }
+    }
+}
+
+function request_method_is(string $method): bool
+{
+    return isset($_SERVER['REQUEST_METHOD']) && strtoupper((string) $_SERVER['REQUEST_METHOD']) === $method;
+}
+
+function request_string(string $key): string
+{
+    if (!isset($_REQUEST[$key])) {
+        return '';
+    }
+
+    $value = $_REQUEST[$key];
+    if (is_array($value)) {
+        return '';
+    }
+
+    return trim((string) $value);
+}
+
+function sanitize_text(mixed $value, int $maxLength): string
+{
+    if (!is_scalar($value)) {
+        return '';
+    }
+
+    $string = trim((string) $value);
+    if ($string === '') {
+        return '';
+    }
+
+    if (function_exists('mb_substr')) {
+        $string = mb_substr($string, 0, $maxLength);
+    } else {
+        $string = substr($string, 0, $maxLength);
+    }
+
+    return $string;
+}
+
+function sanitize_multiline(mixed $value, int $maxLength): string
+{
+    $text = sanitize_text($value, $maxLength);
+    if ($text === '') {
+        return '';
+    }
+
+    return str_replace(["\r\n", "\r"], "\n", $text);
+}
+
+function sanitize_tracking(mixed $value): string
+{
+    $text = sanitize_text($value, 64);
+    if ($text === '') {
+        return '';
+    }
+
+    return (string) preg_replace('/[^a-zA-Z0-9_\-]/', '', $text);
+}
+
+function detect_mime_type(string $path): string
+{
+    if (!is_file($path)) {
+        return '';
+    }
+
+    $finfo = finfo_open(FILEINFO_MIME_TYPE);
+    if ($finfo === false) {
+        return '';
+    }
+
+    $mime = finfo_file($finfo, $path);
+    finfo_close($finfo);
+
+    if (!is_string($mime)) {
+        return '';
+    }
+
+    return $mime;
+}
+
+function build_log_entry(DateTimeImmutable $timestamp, string $relativePath, array $values, array $uploadMeta, array $platformOptions): string
+{
+    $log = [
+        'timestamp' => $timestamp->format(DateTimeInterface::ATOM),
+        'name' => normalize_log_value($values['name'] ?? ''),
+        'email' => normalize_log_value($values['email'] ?? ''),
+        'platform' => $platformOptions[$values['platform']] ?? $values['platform'],
+        'src' => normalize_log_value($values['src'] ?? ''),
+        'camp' => normalize_log_value($values['camp'] ?? ''),
+        'date' => normalize_log_value($values['date'] ?? ''),
+        'notes' => normalize_log_value($values['notes'] ?? ''),
+        'upload' => $relativePath,
+        'original_name' => normalize_log_value($uploadMeta['original_name'] ?? ''),
+        'size' => $uploadMeta['size'] ?? 0,
+    ];
+
+    $json = json_encode($log, JSON_UNESCAPED_SLASHES);
+    if (!is_string($json)) {
+        return '';
+    }
+
+    return $json;
+}
+
+function build_email_body(DateTimeImmutable $timestamp, string $relativePath, array $values, string $platformLabel): string
+{
+    $lines = [
+        'New starter kit claim received on ' . $timestamp->format('Y-m-d H:i:s T') . '.',
+        '',
+        'Name: ' . $values['name'],
+        'Email: ' . $values['email'],
+        'Platform: ' . $platformLabel,
+        'Tracking src: ' . ($values['src'] ?: '(not provided)'),
+        'Tracking camp: ' . ($values['camp'] ?: '(not provided)'),
+        'Tracking date: ' . ($values['date'] ?: '(not provided)'),
+        'Upload path: ' . $relativePath,
+    ];
+
+    if ($values['notes'] !== '') {
+        $lines[] = '';
+        $lines[] = 'Notes:';
+        $lines[] = $values['notes'];
+    }
+
+    return implode("\n", $lines) . "\n";
+}
+
+function normalize_log_value(string $value): string
+{
+    $normalized = (string) preg_replace('/[\r\n\t]+/', ' ', $value);
+    if ($normalized === '') {
+        return '';
+    }
+
+    return trim($normalized);
+}
+
+function esc(string $value): string
+{
+    return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+function field_error(array $errors, string $key): string
+{
+    return $errors[$key] ?? '';
+}
+
+?>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Claim Starter Kit | NaughtyCamSpot</title>
+    <meta name="description" content="Upload proof of your signup so the NaughtyCamSpot concierge can release the starter kit." />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #05060a;
+        --card: rgba(255, 255, 255, 0.06);
+        --card-border: rgba(255, 255, 255, 0.12);
+        --accent: #f8c0c8;
+        --text: rgba(255, 255, 255, 0.9);
+        --muted: rgba(255, 255, 255, 0.65);
+        --error: #ff7b7b;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: radial-gradient(circle at top left, rgba(248, 192, 200, 0.2), transparent 55%),
+          radial-gradient(circle at top right, rgba(248, 192, 200, 0.15), transparent 50%),
+          var(--bg);
+        color: var(--text);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 40px 16px;
+      }
+
+      main {
+        width: 100%;
+        max-width: 720px;
+        background: var(--card);
+        border: 1px solid var(--card-border);
+        border-radius: 28px;
+        padding: 32px;
+        backdrop-filter: blur(16px);
+        box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
+      }
+
+      h1 {
+        font-family: 'Playfair Display', 'Times New Roman', serif;
+        font-size: 2.25rem;
+        margin: 0 0 8px;
+      }
+
+      p {
+        margin: 0 0 16px;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+
+      .field {
+        margin-bottom: 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      label {
+        font-size: 0.75rem;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        color: rgba(255, 255, 255, 0.7);
+      }
+
+      input[type="text"],
+      input[type="email"],
+      select,
+      textarea {
+        width: 100%;
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(5, 6, 10, 0.6);
+        color: var(--text);
+        padding: 12px 16px;
+        font-size: 0.95rem;
+        transition: border-color 0.2s ease, background 0.2s ease;
+      }
+
+      input[type="text"]:focus,
+      input[type="email"]:focus,
+      select:focus,
+      textarea:focus,
+      input[type="file"]:focus {
+        outline: none;
+        border-color: rgba(248, 192, 200, 0.6);
+        background: rgba(5, 6, 10, 0.75);
+      }
+
+      input[type="file"] {
+        color: var(--muted);
+      }
+
+      textarea {
+        min-height: 120px;
+        resize: vertical;
+      }
+
+      button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 14px 32px;
+        border-radius: 999px;
+        border: 1px solid rgba(248, 192, 200, 0.6);
+        background: var(--accent);
+        color: #1a1b1f;
+        text-transform: uppercase;
+        letter-spacing: 0.28em;
+        font-weight: 600;
+        font-size: 0.75rem;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      button:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 20px 40px rgba(248, 192, 200, 0.2);
+      }
+
+      .helper {
+        font-size: 0.75rem;
+        color: rgba(255, 255, 255, 0.55);
+        letter-spacing: 0.04em;
+      }
+
+      .error {
+        color: var(--error);
+        font-size: 0.8rem;
+        letter-spacing: 0.02em;
+      }
+
+      .error-summary {
+        border-radius: 18px;
+        border: 1px solid rgba(255, 123, 123, 0.35);
+        background: rgba(255, 123, 123, 0.08);
+        padding: 16px 18px;
+        margin-bottom: 24px;
+        color: var(--error);
+        font-size: 0.9rem;
+        line-height: 1.5;
+      }
+
+      .steps {
+        margin: 32px 0;
+        display: grid;
+        gap: 18px;
+      }
+
+      .steps span {
+        display: block;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.3em;
+        color: rgba(248, 192, 200, 0.7);
+        margin-bottom: 6px;
+      }
+
+      @media (min-width: 640px) {
+        .steps {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Claim your starter kit</h1>
+      <p>
+        Submit proof of your signup so the NaughtyCamSpot concierge can release the 14-day starter kit. We verify every claim by
+        hand. Weekday responses usually land within 24 hours.
+      </p>
+
+      <div class="steps">
+        <div>
+          <span>Step 1</span>
+          <p class="helper">Complete the partner signup using our tracked link.</p>
+        </div>
+        <div>
+          <span>Step 2</span>
+          <p class="helper">Grab a screenshot of your approval email or dashboard with your username visible.</p>
+        </div>
+        <div>
+          <span>Step 3</span>
+          <p class="helper">Upload the screenshot and add any context below so we can match the referral.</p>
+        </div>
+      </div>
+
+      <?php if (!empty($errors['general'])): ?>
+        <div class="error-summary"><?php echo esc($errors['general']); ?></div>
+      <?php endif; ?>
+
+      <form method="post" enctype="multipart/form-data" novalidate>
+        <input type="hidden" name="src" value="<?php echo esc($values['src']); ?>" />
+        <input type="hidden" name="camp" value="<?php echo esc($values['camp']); ?>" />
+        <input type="hidden" name="date" value="<?php echo esc($values['date']); ?>" />
+        <input type="hidden" name="MAX_FILE_SIZE" value="<?php echo (string) $maxUploadBytes; ?>" />
+
+        <div class="field">
+          <label for="claim-name">Name</label>
+          <input type="text" id="claim-name" name="name" required value="<?php echo esc($values['name']); ?>" autocomplete="name" />
+          <?php if ($message = field_error($errors, 'name')): ?>
+            <span class="error"><?php echo esc($message); ?></span>
+          <?php endif; ?>
+        </div>
+
+        <div class="field">
+          <label for="claim-email">Email</label>
+          <input type="email" id="claim-email" name="email" required value="<?php echo esc($values['email']); ?>" autocomplete="email" />
+          <?php if ($message = field_error($errors, 'email')): ?>
+            <span class="error"><?php echo esc($message); ?></span>
+          <?php endif; ?>
+        </div>
+
+        <div class="field">
+          <label for="claim-platform">Platform</label>
+          <select id="claim-platform" name="platform" required>
+            <option value="" disabled <?php echo $values['platform'] === '' ? 'selected' : ''; ?>>Select a platform</option>
+            <?php foreach ($platformOptions as $optionValue => $label): ?>
+              <option value="<?php echo esc($optionValue); ?>" <?php echo $values['platform'] === $optionValue ? 'selected' : ''; ?>><?php echo esc($label); ?></option>
+            <?php endforeach; ?>
+          </select>
+          <?php if ($message = field_error($errors, 'platform')): ?>
+            <span class="error"><?php echo esc($message); ?></span>
+          <?php endif; ?>
+        </div>
+
+        <div class="field">
+          <label for="claim-screenshot">Signup screenshot (PNG or JPG, max 5&nbsp;MB)</label>
+          <input type="file" id="claim-screenshot" name="signup_screenshot" accept="image/png,image/jpeg" required />
+          <span class="helper">Include your username or referral ID in the screenshot so we can confirm the match.</span>
+          <?php if ($message = field_error($errors, 'signup_screenshot')): ?>
+            <span class="error"><?php echo esc($message); ?></span>
+          <?php endif; ?>
+        </div>
+
+        <div class="field">
+          <label for="claim-notes">Notes (optional)</label>
+          <textarea id="claim-notes" name="notes" placeholder="Share anything we should know about your signup timing or referral credit."><?php echo esc($values['notes']); ?></textarea>
+          <?php if ($message = field_error($errors, 'notes')): ?>
+            <span class="error"><?php echo esc($message); ?></span>
+          <?php endif; ?>
+        </div>
+
+        <button type="submit">Submit claim</button>
+      </form>
+
+      <p class="helper" style="margin-top: 28px;">
+        After approval you&apos;ll receive an email with the full kit plus a direct link to the
+        <a href="/starter-kit" style="color: var(--accent);">starter kit overview</a> for quick reference.
+      </p>
+    </main>
+  </body>
+</html>

--- a/public/claim/success.html
+++ b/public/claim/success.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Starter Kit Claimed | NaughtyCamSpot</title>
+    <meta name="description" content="Your NaughtyCamSpot starter kit claim is confirmed." />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #05060a;
+        --card: rgba(255, 255, 255, 0.05);
+        --border: rgba(255, 255, 255, 0.1);
+        --accent: #f8c0c8;
+        --text: rgba(255, 255, 255, 0.9);
+        --muted: rgba(255, 255, 255, 0.65);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top left, rgba(248, 192, 200, 0.18), transparent 55%),
+          radial-gradient(circle at bottom right, rgba(248, 192, 200, 0.1), transparent 50%),
+          var(--bg);
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        color: var(--text);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 40px 16px;
+      }
+
+      main {
+        max-width: 520px;
+        width: 100%;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 28px;
+        padding: 32px;
+        text-align: center;
+        backdrop-filter: blur(16px);
+        box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
+      }
+
+      h1 {
+        font-family: 'Playfair Display', 'Times New Roman', serif;
+        font-size: 2rem;
+        margin: 0 0 12px;
+      }
+
+      p {
+        margin: 0 0 18px;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+
+      a.button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 14px 32px;
+        border-radius: 999px;
+        border: 1px solid rgba(248, 192, 200, 0.6);
+        background: var(--accent);
+        color: #1a1b1f;
+        text-transform: uppercase;
+        letter-spacing: 0.28em;
+        font-weight: 600;
+        font-size: 0.75rem;
+        text-decoration: none;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      a.button:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 20px 40px rgba(248, 192, 200, 0.2);
+      }
+
+      .helper {
+        font-size: 0.8rem;
+        color: rgba(255, 255, 255, 0.55);
+        letter-spacing: 0.04em;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Claim received</h1>
+      <p>
+        Thanks for sending your proof. The concierge team is reviewing it now. You&apos;ll get the 14-day starter kit from
+        concierge@naughtycamspot.com as soon as the referral is confirmed.
+      </p>
+      <a class="button" href="/starter-kit">Browse starter kit overview</a>
+      <p class="helper">Need to update your claim? Reply to the confirmation email with extra details or a fresh screenshot.</p>
+    </main>
+  </body>
+</html>

--- a/public/claim/uploads/.gitignore
+++ b/public/claim/uploads/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.htaccess

--- a/public/claim/uploads/.htaccess
+++ b/public/claim/uploads/.htaccess
@@ -1,0 +1,13 @@
+Options -ExecCGI
+<IfModule mod_php.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php8.c>
+  php_flag engine off
+</IfModule>
+<FilesMatch "\.(php|phtml|phar|cgi|pl|py|rb|sh)$">
+  Require all denied
+</FilesMatch>

--- a/src/pages/claim.astro
+++ b/src/pages/claim.astro
@@ -1,0 +1,92 @@
+---
+import MainLayout from '../layouts/MainLayout.astro';
+import { getClaimUrl, withBase } from '../utils/links';
+
+const claimUrl = getClaimUrl();
+const claimLinkIsExternal = claimUrl.startsWith('http');
+const claimLinkTarget = claimLinkIsExternal ? '_blank' : undefined;
+const claimLinkRel = claimLinkIsExternal ? 'noreferrer' : undefined;
+
+const proofSteps = [
+  {
+    title: 'Finish your signup',
+    detail:
+      'Complete the program application using our tracked link. Make sure the email address on the form matches the platform account so we can confirm the referral credit.'
+  },
+  {
+    title: 'Capture verification proof',
+    detail:
+      'Take a clear screenshot showing the platform dashboard or confirmation email with your username visible. We use this to match your referral ID.'
+  },
+  {
+    title: 'Submit the claim form',
+    detail:
+      'Upload the screenshot, share any notes, and send us the best reply-to email. The concierge team double-checks the credit before releasing the kit.'
+  }
+];
+
+const followUpNotes = [
+  'We aim to confirm claims within one business day. Weekends may take a touch longer.',
+  'The starter kit ships from concierge@naughtycamspot.com once the referral clears—add us to your safe senders list so nothing lands in spam.',
+  'You can review the full kit contents any time on the starter kit overview page.'
+];
+---
+
+<MainLayout
+  title="Claim Starter Kit | NaughtyCamSpot"
+  description="Submit proof of your partner signup to unlock the NaughtyCamSpot 14-day starter kit."
+>
+  <section class="content-card space-y-6">
+    <div class="space-y-4">
+      <span class="hero-tagline">Starter kit verification</span>
+      <h1 class="font-display text-4xl text-white sm:text-5xl">Claim your 14-day starter kit</h1>
+      <p class="max-w-2xl text-sm text-white/70">
+        Finish your partner signup, gather a screenshot that proves the referral, and send it through this claim flow. We verify
+        every submission manually so your launch plan stays exclusive to active models.
+      </p>
+    </div>
+    <a
+      class="inline-flex w-fit items-center justify-center rounded-full border border-rose-gold/60 bg-rose-gold px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-midnight shadow-glow transition hover:-translate-y-1"
+      href={claimUrl}
+      target={claimLinkTarget}
+      rel={claimLinkRel}
+    >
+      Open claim form
+    </a>
+    <p class="text-xs uppercase tracking-[0.3em] text-white/45">
+      {claimLinkIsExternal
+        ? 'Routes to our secure intake on Tally.'
+        : 'Opens the secure claim form hosted on naughtycamspot.com.'}
+    </p>
+  </section>
+
+  <section class="space-y-6">
+    <h2 class="section-heading">Proof checklist</h2>
+    <ol class="grid gap-4 text-sm text-white/70 md:grid-cols-3">
+      {proofSteps.map((step, index) => (
+        <li class="content-card space-y-3">
+          <span class="text-xs uppercase tracking-[0.3em] text-rose-petal/70">Step {index + 1}</span>
+          <p class="font-semibold text-white">{step.title}</p>
+          <p class="text-white/70">{step.detail}</p>
+        </li>
+      ))}
+    </ol>
+  </section>
+
+  <section class="content-card space-y-5">
+    <h2 class="section-heading">After you submit</h2>
+    <ul class="grid gap-3 text-sm text-white/70">
+      {followUpNotes.map((note) => (
+        <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">{note}</li>
+      ))}
+    </ul>
+    <p class="text-sm text-white/65">
+      After you submit the form we surface a direct link to the{' '}
+      <a class="text-rose-gold underline-offset-4 hover:underline" href={withBase('/starter-kit')}>
+        starter kit overview
+      </a>{' '}
+      so you can download everything immediately. Bookmark it now if you want a sneak peek at the daily prompts, pricing ladders,
+      and lighting checklists.
+    </p>
+  </section>
+</MainLayout>

--- a/src/pages/join-models.astro
+++ b/src/pages/join-models.astro
@@ -1,7 +1,7 @@
 ---
 import BannerSlot from '../components/BannerSlot.astro';
 import MainLayout from '../layouts/MainLayout.astro';
-import { buildTrackedLink, isPagesBuild } from '../utils/links';
+import { buildTrackedLink, getClaimUrl, isPagesBuild } from '../utils/links';
 
 const heroBullets = [
   {
@@ -53,6 +53,35 @@ const ctaHref = buildTrackedLink({
   placeholder: CTA_PLACEHOLDER
 });
 const pagesBuild = isPagesBuild();
+const claimUrl = getClaimUrl();
+const claimLinkIsExternal = claimUrl.startsWith('http');
+const claimLinkTarget = claimLinkIsExternal ? '_blank' : undefined;
+const claimLinkRel = claimLinkIsExternal ? 'noreferrer' : undefined;
+
+const onboardingSteps = [
+  {
+    title: 'Choose your launch partner',
+    detail:
+      'Pick the cam platform that fits your goals, complete the official signup, and keep the welcome email handy for reference.'
+  },
+  {
+    title: 'Send verification proof',
+    detail:
+      'Forward the confirmation screenshot or referral code to concierge@naughtycamspot.com so we can match your account to our affiliate record.'
+  },
+  {
+    title: 'Claim the starter kit',
+    detail:
+      'Once the referral clears, submit the claim form with your screenshot and delivery notes so the concierge team can ship the launch bundle.',
+    cta: {
+      href: claimUrl,
+      target: claimLinkTarget,
+      rel: claimLinkRel,
+      external: claimLinkIsExternal,
+      label: 'Open claim form'
+    }
+  }
+];
 ---
 
 <MainLayout
@@ -105,6 +134,36 @@ const pagesBuild = isPagesBuild();
       </div>
       <BannerSlot id="model_sidebar_tall" class="w-full" />
     </div>
+  </section>
+
+  <section class="content-card space-y-6">
+    <div class="space-y-3">
+      <h2 class="section-heading">Claim sequence</h2>
+      <p class="text-sm text-white/70">
+        Keep proof handy so we can release the kit quickly. Step three routes to the secure claim form where you&apos;ll upload your
+        screenshot and leave delivery notes for the concierge team.
+      </p>
+    </div>
+    <ol class="grid gap-4 text-sm text-white/70 md:grid-cols-3">
+      {onboardingSteps.map((step, index) => (
+        <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">
+          <span class="text-xs uppercase tracking-[0.3em] text-rose-petal/70">Step {index + 1}</span>
+          <p class="mt-2 font-semibold text-white">{step.title}</p>
+          <p class="mt-1 text-white/70">{step.detail}</p>
+          {step.cta && (
+            <a
+              class="mt-3 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-gold transition hover:text-rose-petal"
+              href={step.cta.href}
+              target={step.cta.target}
+              rel={step.cta.rel}
+            >
+              {step.cta.label}
+              {step.cta.external && <span aria-hidden="true">↗</span>}
+            </a>
+          )}
+        </li>
+      ))}
+    </ol>
   </section>
 
   <section class="space-y-10">

--- a/src/utils/links.d.ts
+++ b/src/utils/links.d.ts
@@ -8,6 +8,7 @@ export type BuildTrackedLinkOptions = {
 export declare const isPagesBuild: () => boolean;
 export declare const withBase: (path?: string) => string;
 export declare const buildTrackedLink: (options: BuildTrackedLinkOptions) => string;
+export declare const getClaimUrl: () => string;
 export declare const __test: {
   formatDateStamp: () => string;
   sanitizePlaceholder: (value: string) => string;

--- a/src/utils/links.js
+++ b/src/utils/links.js
@@ -11,6 +11,9 @@ const envBaseUrl =
 const BASE_URL = runtimeBaseUrl ?? envBaseUrl ?? '/';
 const IS_PAGES_BUILD = BASE_URL !== '/';
 
+const CLAIM_FORM_EXTERNAL_URL = 'https://tally.so/r/claim-starter-kit';
+const CLAIM_FORM_INTERNAL_PATH = '/claim/';
+
 const sanitizePlaceholder = (placeholder) => {
   if (!placeholder) {
     return '';
@@ -62,5 +65,7 @@ export const buildTrackedLink = ({ path, slot, camp, placeholder }) => {
 
   return `${normalizedPath}${queryGlue}${tracking}`;
 };
+
+export const getClaimUrl = () => (IS_PAGES_BUILD ? CLAIM_FORM_EXTERNAL_URL : CLAIM_FORM_INTERNAL_PATH);
 
 export const __test = { formatDateStamp, sanitizePlaceholder };


### PR DESCRIPTION
## Summary
- add a dedicated claim instructions page in Astro that flips between the external intake and /claim depending on the build
- ship the ViceTemple claim form with upload validation, logging, success redirect, and folder hardening
- document the starter kit claim flow and update join-models to surface the new helper

## Testing
- `npm run build:pages`

Pages preview: https://leecuevasowner.github.io/naughtycamspot/claim

![Claim starter kit page](browser:/invocations/klsbiofj/artifacts/artifacts/claim-page.png)
![Claim success confirmation](browser:/invocations/ilzssycx/artifacts/artifacts/claim-success.png)

------
https://chatgpt.com/codex/tasks/task_e_68f28d85aea48326825fd8216dfc5fcf