### PR TITLE
chore: make /public/go authoritative + strip from Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,6 +35,8 @@ jobs:
         run: cp public/robots.pages.txt public/robots.txt
       - name: Build (Pages config)
         run: npx astro build --config astro.config.pages.mjs
+      - name: Strip PHP redirectors from Pages artifact
+        run: rm -rf dist/go
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Luxury gallery frontend for Naughty Cam Spot, built with Astro and Tailwind CSS.
 - Create a production build: `npm run build`
 - Build for GitHub Pages: `npm run build:pages`
 
+## Deploy model
+
+- Run a local production build and upload the generated `dist/` directory to ViceTemple.
+- Treat `/public/go` as the canonical source inside the repo — never hand-edit PHP on the server.
+- The Pages workflow deletes `dist/go`, so GitHub Pages never ships the PHP redirectors.
+
 ## Project structure
 
 - `src/layouts/MainLayout.astro` — shared chrome, fonts, and ambient gradients

--- a/public/go/.htaccess
+++ b/public/go/.htaccess
@@ -1,0 +1,6 @@
+Options -Indexes
+<IfModule mod_headers.c>
+    Header set Cache-Control "no-store"
+    Header set X-Content-Type-Options "nosniff"
+    Header set Referrer-Policy "strict-origin-when-cross-origin"
+</IfModule>

--- a/public/go/affiliates.php
+++ b/public/go/affiliates.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 const GO_SUBID_PARAM = 'subid';
 const GO_MODEL_PROGRAM_CONFIG = [
     'bonga' => [
-        'active' => true,
+        'active' => false,
         'tiers' => ['T1', 'T2', 'T3', 'T4'],
     ],
     'camsoda' => [
@@ -17,7 +17,7 @@ const GO_MODEL_PROGRAM_CONFIG = [
         'tiers' => ['T1', 'T2', 'T3', 'T4'],
     ],
     'of_creator' => [
-        'active' => true,
+        'active' => false,
         'tiers' => ['T1', 'T2', 'T3', 'T4'],
     ],
     'myclub' => [
@@ -206,16 +206,23 @@ function go_build_bonga_model_signup(string $subid, array $context = []): string
 
 function go_build_camsoda_model_signup(string $subid): string
 {
-    $base = 'https://track.naughtycamspot.com/camsoda/models';
+    $base = 'https://www.camsoda.com/models?id=naughtycamboss';
+    $tracking = $subid !== '' ? $subid : 'default';
+    $query = http_build_query([
+        's1' => $tracking,
+        'track' => $tracking,
+    ], '', '&', PHP_QUERY_RFC3986);
 
-    return go_append_subid($base, $subid);
+    $separator = strpos($base, '?') !== false ? '&' : '?';
+
+    return $base . $separator . $query;
 }
 
 function go_build_chaturbate_model_signup(string $subid): string
 {
-    $base = 'https://track.naughtycamspot.com/chaturbate/models';
+    $tracking = $subid !== '' ? $subid : 'default';
 
-    return go_append_subid($base, $subid);
+    return 'https://chaturbate.com/in/?tour=5zjT&campaign=YIOhf&track=' . rawurlencode($tracking);
 }
 
 function go_build_onlyfans_creator_signup(string $subid): string


### PR DESCRIPTION
## Summary
- keep the `/public/go` PHP redirectors in git with an .htaccess for server-side headers
- wire the CamSoda and Chaturbate model programs to the live tracking bases and leave the rest disabled by default
- drop `dist/go` from the GitHub Pages artifact and document the ViceTemple deployment flow

## Testing
- npm run build:pages

## Screenshots
- Pending: Pages artifact listing (no `dist/go`) will be attached after the workflow runs.

## Affiliate bases
- CamSoda: `https://www.camsoda.com/models?id=naughtycamboss&s1=<subid>&track=<subid>`
- Chaturbate: `https://chaturbate.com/in/?tour=5zjT&campaign=YIOhf&track=<subid>`

------
https://chatgpt.com/codex/tasks/task_e_68f2d5f628348326a3354238f159b031