### PR TITLE
feat: claim flow, starter kit, recruiting blog seed

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,37 @@
+name: Deploy Pages Preview
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build (Pages config)
+        run: npx astro build --config astro.config.pages.mjs
+      - name: Remove server-only files from Pages
+        run: rm -rf dist/go
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 dist/
 .astro/
 public/claim/claims.log
+exports/

--- a/build_prod_zip.sh
+++ b/build_prod_zip.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$REPO_ROOT" ]]; then
+  echo "Run from within a git repository." >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+
+for cmd in git npm zip; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: $cmd" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f package.json || ! -f astro.config.mjs ]]; then
+  echo "Run this script from the project root." >&2
+  exit 1
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+ZIP_NAME="ncs_dist_$(date +%Y%m%d_%H%M).zip"
+
+echo "→ Fetching latest main"
+git fetch origin --prune
+if git show-ref --verify --quiet refs/heads/main; then
+  git checkout main
+else
+  echo "Branch 'main' not found." >&2
+  exit 1
+fi
+git pull --ff-only origin main
+
+echo "→ Installing dependencies & building"
+rm -rf dist
+npm ci
+npx astro build
+
+if [[ -f dist/robots.prod.txt ]]; then
+  cp dist/robots.prod.txt dist/robots.txt
+fi
+
+if [[ ! -d dist/go ]]; then
+  echo "dist/go missing after build." >&2
+  exit 1
+fi
+PHP_COUNT=$(find dist/go -maxdepth 1 -type f -name '*.php' | wc -l | tr -d ' ')
+if [[ "$PHP_COUNT" == "0" ]]; then
+  echo "No PHP redirectors found in dist/go." >&2
+  exit 1
+fi
+
+echo "→ Creating $ZIP_NAME"
+(cd dist && zip -r "../$ZIP_NAME" . -x "*.DS_Store")
+
+echo "✅ Build complete: $ZIP_NAME"
+
+echo "→ Restoring branch $CURRENT_BRANCH"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  git checkout "$CURRENT_BRANCH"
+fi

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "astro build",
     "build:pages": "astro build --config astro.config.pages.mjs",
     "preview": "astro preview",
-  "test": "node --test \"tests/**/*.mjs\" && vitest run"
+    "test": "node --test \"tests/**/*.mjs\" && vitest run",
+    "export:kit": "concurrently -k \"npm run dev\" \"node scripts/export-starter-kit.js\""
   },
   "dependencies": {
     "@astrojs/sitemap": "file:vendor/astrojs-sitemap",
@@ -19,6 +20,8 @@
     "tailwindcss": "^3.4.13"
   },
   "devDependencies": {
+    "concurrently": "^9.1.0",
+    "puppeteer": "^23.7.0",
     "vitest": "^1.6.0"
   }
 }

--- a/public/claim/.htaccess
+++ b/public/claim/.htaccess
@@ -9,9 +9,21 @@
   </LimitExcept>
 </IfModule>
 
-Options -ExecCGI
+Options -ExecCGI -Indexes
+
+<IfModule mod_headers.c>
+  Header always set Cache-Control "no-store, no-cache, must-revalidate, max-age=0"
+  Header always set Pragma "no-cache"
+</IfModule>
 
 <IfModule mod_rewrite.c>
   RewriteEngine On
+  RewriteRule ^uploads/ - [E=NCS_UPLOADS:1]
   RewriteRule ^uploads/.*\.(?:php|phtml|phar|cgi|pl|py|rb|sh)$ - [F,L]
+</IfModule>
+
+<IfModule mod_headers.c>
+  Header always set Cache-Control "no-store, no-cache, must-revalidate, max-age=0" env=NCS_UPLOADS
+  Header always set Pragma "no-cache" env=NCS_UPLOADS
+  Header always set Content-Disposition "attachment" env=NCS_UPLOADS
 </IfModule>

--- a/scripts/export-starter-kit.js
+++ b/scripts/export-starter-kit.js
@@ -1,0 +1,54 @@
+import { mkdir } from 'node:fs/promises';
+import { setTimeout as delay } from 'node:timers/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+const outputDir = join(projectRoot, 'exports');
+const outputPath = join(outputDir, 'starter-kit.pdf');
+const targetUrl = process.env.STARTER_KIT_URL ?? 'http://localhost:4321/starter-kit';
+
+const log = (message) => process.stdout.write(`${message}\n`);
+
+try {
+  log(`⏳ Launching headless browser for ${targetUrl}`);
+  const browser = await puppeteer.launch({ headless: 'new' });
+
+  try {
+    const page = await browser.newPage();
+    page.setDefaultNavigationTimeout(120_000);
+
+    let loaded = false;
+    let attempt = 0;
+    let lastError;
+
+    while (!loaded && attempt < 30) {
+      attempt += 1;
+      try {
+        await page.goto(targetUrl, { waitUntil: 'networkidle0' });
+        loaded = true;
+      } catch (error) {
+        lastError = error;
+        log(`… Waiting for dev server (attempt ${attempt}/30)`);
+        await delay(1_000);
+      }
+    }
+
+    if (!loaded) {
+      throw lastError ?? new Error('Could not reach starter kit page');
+    }
+
+    await mkdir(outputDir, { recursive: true });
+    log(`🖨️  Rendering PDF to ${outputPath}`);
+    await page.pdf({ path: outputPath, format: 'A4', printBackground: true });
+    log('✅ Starter kit exported');
+  } finally {
+    await browser.close();
+  }
+} catch (error) {
+  console.error('Failed to export starter kit PDF');
+  console.error(error);
+  process.exitCode = 1;
+}

--- a/src/content/blog/14-day-launch-plan.md
+++ b/src/content/blog/14-day-launch-plan.md
@@ -1,0 +1,33 @@
+---
+title: '14-Day Launch Plan'
+description: 'Map out the two-week runway we use inside the starter kit to turn new signups into confident, profitable performers.'
+excerpt: 'Preview the exact 14-day plan the concierge team deploys for new models so you know what happens after your claim clears.'
+publishDate: 2024-10-08
+category: 'Concierge Systems'
+author: 'Lina, Data Strategist'
+heroImage: 'https://images.unsplash.com/photo-1529333166437-7750a6dd5a70?auto=format&fit=crop&w=1600&q=80'
+heroImageAlt: 'Daily planner with handwritten show schedule'
+cardImage: 'https://images.unsplash.com/photo-1506784983877-45594efa4cbe?auto=format&fit=crop&w=1200&q=80'
+---
+
+## Phase 1: Orientation (Days 1–3)
+
+We stabilise your tools, persona, and compliance. Day one is account hygiene: password vault, payout profiles, and ID backups. Day two focuses on lighting rehearsals with the concierge team, while day three locks your base show script.
+
+## Phase 2: Soft open (Days 4–6)
+
+You host short rehearsal streams to warm the room. We rotate through the three show scripts included in the kit so your mods learn each cadence. Capture performance notes after every stream—this data powers later adjustments.
+
+## Phase 3: Signature debut (Day 7)
+
+Your official launch lands on day seven. You run the hero script, introduce your tip ladder, and activate the concierge tipping tracker. Mods greet VIPs by name and nudge viewers toward the next show time before you log off.
+
+## Phase 4: Momentum stacking (Days 8–11)
+
+We analyse your first week, then double down. You stream every other day, alternating between your primary and VIP scripts. Between shows you send custom DM touchpoints using the templates from the starter kit.
+
+## Phase 5: Expansion (Days 12–14)
+
+We close with a collaboration or themed night, plus a post-launch survey for your top tippers. By day 14 you have baseline conversion data, a refined tip menu, and a concierge debrief scheduled to plan your next milestone.
+
+Secure the starter kit as soon as your signup is approved so we can plug you into the full calendar with templates, pricing ladders, and aftercare scripts.

--- a/src/content/blog/bongacash-model-bounty-tiers.md
+++ b/src/content/blog/bongacash-model-bounty-tiers.md
@@ -1,0 +1,35 @@
+---
+title: 'BongaCash Model Bounty Tiers'
+description: 'Understand the bounty ladder for BongaCash referrals and how to pace your conversions through the first three tiers.'
+excerpt: 'Break down the BongaCash bounty program with concierge pacing tips so you earn each tier without burning your audience.'
+publishDate: 2024-10-05
+category: 'Affiliate Strategy'
+author: 'Elena, Head of Growth'
+heroImage: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1600&q=80'
+heroImageAlt: 'Close-up of a performer planning strategy on a glass board'
+cardImage: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80'
+---
+
+## How the bounty ladder works
+
+BongaCash pays out flat-rate bounties for each verified referral, escalating as you prove consistency. Tier one covers your first 10 signups, tier two runs through 30, and tier three unlocks premium concierge perks. Each tier resets monthly, so pacing matters.
+
+The concierge team watches these tiers closely because they influence when we release extra creative assets. If you push too hard early on, you risk churn from cold traffic who never become loyal fans. We prefer stacking warm leads gathered through your shows and social storytelling.
+
+## Tier one: Proof of concept
+
+Aim to convert your most supportive fans here. Share a candid story about why you chose BongaCash and spotlight the exclusive welcome bonus they receive. Keep your messaging intimate. We recommend no more than three call-outs per stream during this phase.
+
+## Tier two: Scaled invitation
+
+Once you have proof, widen the funnel. Host a themed stream where mods can answer program questions in chat. Highlight your progress with the concierge tracker and create a tip goal tied to an exclusive video drop when the tier locks.
+
+## Tier three: VIP runway
+
+At this stage, focus on quality control. Tier three referrals trigger higher bounty payouts, but the partners review them carefully. Use the starter kit&apos;s DM templates to follow up with prospects before sending them the link. You want genuinely motivated models joining through you.
+
+## Protecting your audience
+
+Never blast raw links without context. Instead, weave the offer into your 14-day runway content so fans see it as a curated opportunity. When you claim your starter kit, we share the compliance cheatsheet that keeps your copy inside Bonga&apos;s guidelines.
+
+Finally, schedule weekly retros with concierge so we can tweak your copy and track conversion velocity. A steady cadence unlocks the bonuses faster than a messy burst.

--- a/src/content/blog/camsoda-vs-chaturbate-for-beginners.md
+++ b/src/content/blog/camsoda-vs-chaturbate-for-beginners.md
@@ -1,0 +1,41 @@
+---
+title: 'CamSoda vs. Chaturbate for Beginners'
+description: 'A concierge-level walkthrough of both platforms so first-time streamers can choose the right launch runway.'
+excerpt: 'Compare CamSoda and Chaturbate across onboarding, traffic, moderation, and monetisation rituals designed for new performers.'
+publishDate: 2024-10-01
+category: 'Platform Guides'
+author: 'Concierge Team'
+heroImage: 'https://images.unsplash.com/photo-1530035415919-d499f3fbeaa4?auto=format&fit=crop&w=1600&q=80'
+heroImageAlt: 'Performer framed by two neon spotlights in a dark studio'
+cardImage: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80'
+---
+
+## Why this decision matters
+
+Your launch platform sets the tone for your whole concierge partnership. The approval queue, how fast tippers discover you, and even which payment processor deposits first all change how your first fourteen days feel. CamSoda and Chaturbate both send traffic, but their cultures reward different rituals.
+
+CamSoda feels like a boutique nightclub. Viewers expect higher production value and respond to curated themes. Chaturbate is more of a bustling festival with constant discovery mode. Knowing that vibe helps you script your first show and decide whether to prioritise lighting or moderator choreography.
+
+## Onboarding and verification
+
+CamSoda usually approves new models within 24 hours if your ID photos are crisp and you list at least one social handle. They prefer performers who already have a brand arc. Chaturbate can take slightly longer but offers immediate access to a sandbox room where you can rehearse while waiting.
+
+For both platforms, keep your sign-up screenshots ready. The concierge team needs them when you submit the starter kit claim so we can match referral IDs.
+
+## Traffic and discovery
+
+CamSoda surfaces new creators through curated carousels, so timing your debut slot is everything. Aim for evenings in North America with a strong concept image on your thumbnail. Chaturbate pushes volume—consistent logins and quirky topic tags help you stay on the front page rotation.
+
+Regardless of platform, announce your show schedule through socials and prime your VIP prospects to be in the room. Concierge analytics show that pre-warmed tippers triple your first-week revenue.
+
+## Monetisation rituals
+
+CamSoda leans into premium DMs and custom menu sales. Build a tip ladder that escalates toward private show bundles. Chaturbate responds well to gamified countdowns and group goals. Rotate between flirty mini-goals and a hero reward every 20 minutes.
+
+Whichever path you pick, keep your first fourteen days focused on the same rituals so data stays clean. We can tweak your menu after the starter kit rollout if your room energy pulls higher spenders than expected.
+
+## Mod support and safety
+
+Chaturbate has a larger volunteer mod community ready to help, but you must set boundaries around ban policies and pacing. CamSoda offers concierge mod referrals for performers willing to host themed nights. Brief your mod team using the show scripts inside the starter kit so everyone welcomes fans the same way.
+
+Remember: either platform works when you pair it with the 14-day runway. Choose the environment that matches your personality, then lock in the claim flow immediately after signup so we can release the kit without delays.

--- a/src/content/blog/first-stream-checklist-under-100.md
+++ b/src/content/blog/first-stream-checklist-under-100.md
@@ -1,0 +1,33 @@
+---
+title: 'First Stream Checklist Under $100'
+description: 'Assemble a polished first stream without overspending—gear, lighting, and ambience under one hundred dollars.'
+excerpt: 'Use this under-$100 checklist to stage your debut stream with concierge-level polish before your first tip lands.'
+publishDate: 2024-09-28
+category: 'Launch Playbooks'
+author: 'Milo, Community Director'
+heroImage: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1600&q=80'
+heroImageAlt: 'Budget-friendly streaming setup with tripod light and laptop'
+cardImage: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80'
+---
+
+## Set the foundation
+
+Start with the room before touching tech. Wipe down your backdrop, clear clutter, and add one focal prop that matches your persona. Place a full-length mirror behind the camera so you can adjust posture between segments. This costs nothing but instantly increases polish.
+
+## Lighting on a budget
+
+Buy two clip-on LED lamps (around $15 each) and a pack of warm diffusion gels. Position one lamp at a 45-degree angle for key light and bounce the second off a white wall as fill. A strand of fairy lights adds depth behind you. These notes are expanded inside the starter kit&apos;s lighting checklist.
+
+## Audio that flatters
+
+Use wired earbuds with an inline mic instead of your laptop microphone. Wrap the mic in a tiny piece of foam to soften sibilance. If you have $20 left, invest in a desktop gooseneck stand so you can position the mic consistently.
+
+## Ambience and scent
+
+Light a candle that matches your room story—vanilla for cozy, sandalwood for luxe. Keep a fan or AC unit off during the show to avoid noise. Prep a hydration ritual so your voice stays silky when you switch between show scripts.
+
+## Final rehearsal
+
+Do a 15-minute dry run using one of the starter kit scripts. Practice your intro line, your first tip goal call-out, and the closing gratitude routine. Capture a screenshot for your claim submission while you rehearse so it&apos;s ready for concierge review.
+
+You can create magic on a tight budget when every detail is intentional. Use this checklist alongside the full 14-day launch plan we send after your claim clears.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -35,4 +35,19 @@ const models = defineCollection({
   })
 });
 
-export const collections = { models };
+const blog = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    excerpt: z.string(),
+    publishDate: z.date(),
+    category: z.string(),
+    author: z.string(),
+    heroImage: z.string().url(),
+    heroImageAlt: z.string().optional(),
+    cardImage: z.string().url().optional()
+  })
+});
+
+export const collections = { models, blog };

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,41 +1,24 @@
 ---
+import { getCollection } from 'astro:content';
 import MainLayout from '../layouts/MainLayout.astro';
 import { withBase } from '../utils/links';
 
-const posts = [
-  {
-    slug: 'luxury-room-energy',
-    title: 'Crafting Luxury Room Energy',
-    excerpt: 'Five sensory cues that immediately elevate your room and prime viewers to invest deeply in your show narrative.',
-    category: 'Strategy',
-    image: 'https://images.unsplash.com/photo-1514525253161-7a46d19cd819?auto=format&fit=crop&w=900&q=80',
-    date: 'September 28, 2025'
-  },
-  {
-    slug: 'vip-funnel-design',
-    title: 'VIP Funnel Design That Converts',
-    excerpt: 'How to transform casual tipping energy into long-form patronage using layered rituals and concierge cues.',
-    category: 'Growth',
-    image: 'https://images.unsplash.com/photo-1478720568477-152d9b164e26?auto=format&fit=crop&w=900&q=80',
-    date: 'October 04, 2025'
-  },
-  {
-    slug: 'mod-team-choreography',
-    title: 'Mod Team Choreography Essentials',
-    excerpt: 'Synchronize your moderators like a luxury hospitality team to keep fan journeys smooth, attentive, and generous.',
-    category: 'Community',
-    image: 'https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?auto=format&fit=crop&w=900&q=80',
-    date: 'October 10, 2025'
-  },
-  {
-    slug: 'ai-concierge-insights',
-    title: 'AI Concierge Insights for Live Shows',
-    excerpt: 'Using your performance data to pre-empt tipping spikes, design mood arcs, and honour your personal bandwidth.',
-    category: 'Technology',
-    image: 'https://images.unsplash.com/photo-1531297484001-80022131f5a1?auto=format&fit=crop&w=900&q=80',
-    date: 'October 14, 2025'
-  }
-];
+const rawPosts = await getCollection('blog');
+const posts = rawPosts
+  .slice()
+  .sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime())
+  .map((entry) => ({
+    slug: entry.slug,
+    title: entry.data.title,
+    excerpt: entry.data.excerpt,
+    category: entry.data.category,
+    date: new Intl.DateTimeFormat('en-US', {
+      month: 'long',
+      day: '2-digit',
+      year: 'numeric'
+    }).format(entry.data.publishDate),
+    image: entry.data.cardImage ?? entry.data.heroImage
+  }));
 ---
 
 <MainLayout
@@ -57,7 +40,7 @@ const posts = [
   <!-- SECTION: Blog Grid -->
   <section class="grid gap-6 sm:grid-cols-2">
     {posts.map((post, index) => (
-      <article class="content-card overflow-hidden" style={`animation-delay: ${index * 0.1}s`}>
+      <article class="content-card group overflow-hidden" style={`animation-delay: ${index * 0.1}s`}>
         <div class="relative overflow-hidden rounded-3xl">
           <img src={post.image} alt={post.title} class="h-52 w-full object-cover" loading="lazy" />
           <div class="absolute inset-0 bg-gradient-to-t from-midnight via-transparent to-transparent opacity-80 transition group-hover:opacity-60"></div>
@@ -68,7 +51,10 @@ const posts = [
           <p class="text-sm text-white/70">{post.excerpt}</p>
           <div class="flex items-center justify-between text-xs text-white/50">
             <span>{post.date}</span>
-            <a class="uppercase tracking-[0.35em] text-rose-petal transition hover:text-rose-gold" href={withBase(`/blog/${post.slug}`)}>
+            <a
+              class="uppercase tracking-[0.35em] text-rose-petal transition hover:text-rose-gold"
+              href={withBase(`/blog/${post.slug}`)}
+            >
               Read More ↗
             </a>
           </div>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,102 +1,100 @@
 ---
+import { getCollection } from 'astro:content';
 import BannerSlot from '../../components/BannerSlot.astro';
 import MainLayout from '../../layouts/MainLayout.astro';
-import { withBase } from '../../utils/links';
+import { buildTrackedLink, getClaimUrl, isPagesBuild, withBase } from '../../utils/links';
 
-export function getStaticPaths() {
-  const articles = [
-    {
-      slug: 'luxury-room-energy',
-      title: 'Crafting Luxury Room Energy',
-      author: 'Concierge Team',
-      date: 'September 28, 2025',
-      image: 'https://images.unsplash.com/photo-1514525253161-7a46d19cd819?auto=format&fit=crop&w=1200&q=80',
-      category: 'Strategy'
-    },
-    {
-      slug: 'vip-funnel-design',
-      title: 'VIP Funnel Design That Converts',
-      author: 'Elena, Head of Growth',
-      date: 'October 04, 2025',
-      image: 'https://images.unsplash.com/photo-1478720568477-152d9b164e26?auto=format&fit=crop&w=1200&q=80',
-      category: 'Growth'
-    },
-    {
-      slug: 'mod-team-choreography',
-      title: 'Mod Team Choreography Essentials',
-      author: 'Milo, Community Director',
-      date: 'October 10, 2025',
-      image: 'https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?auto=format&fit=crop&w=1200&q=80',
-      category: 'Community'
-    },
-    {
-      slug: 'ai-concierge-insights',
-      title: 'AI Concierge Insights for Live Shows',
-      author: 'Lina, Data Strategist',
-      date: 'October 14, 2025',
-      image: 'https://images.unsplash.com/photo-1531297484001-80022131f5a1?auto=format&fit=crop&w=1200&q=80',
-      category: 'Technology'
-    }
-  ];
+const formatDate = (date: Date) =>
+  new Intl.DateTimeFormat('en-US', { month: 'long', day: '2-digit', year: 'numeric' }).format(date);
 
-  return articles.map((entry) => ({
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  const sorted = posts.slice().sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime());
+
+  return sorted.map((entry) => ({
     params: { slug: entry.slug },
     props: {
-      article: entry,
-      related: articles.filter((item) => item.slug !== entry.slug).slice(0, 3)
+      post: entry,
+      related: sorted.filter((item) => item.slug !== entry.slug).slice(0, 3)
     }
   }));
 }
 
-const { article, related } = Astro.props;
+const { post, related } = Astro.props;
+const { Content } = await post.render();
+
+const claimUrl = getClaimUrl();
+const claimLinkIsExternal = claimUrl.startsWith('http');
+const claimLinkTarget = claimLinkIsExternal ? '_blank' : undefined;
+const claimLinkRel = claimLinkIsExternal ? 'noreferrer' : undefined;
+
+const pagesBuild = isPagesBuild();
+const joinHref = buildTrackedLink({
+  path: '/go/model-join.php',
+  slot: `blog_${post.slug}`,
+  camp: 'post',
+  placeholder: 'https://naughtycamspot.com/models'
+});
+const joinLinkTarget = pagesBuild ? '_blank' : undefined;
+const joinLinkRel = pagesBuild ? 'noreferrer' : 'nofollow noreferrer';
+const joinCtaLabel = pagesBuild ? 'Join our concierge roster' : 'Join via tracked concierge';
 ---
 
 <MainLayout
-  title={`${article.title} | NaughtyCamSpot Journal`}
-  description={`Read ${article.title} on the NaughtyCamSpot journal.`}
+  title={`${post.data.title} | NaughtyCamSpot Journal`}
+  description={post.data.description}
 >
   <!-- SECTION: Hero -->
   <article class="space-y-10">
     <header class="hero-shell parallax-veil">
       <div class="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 via-transparent to-black/70"></div>
       <div class="relative space-y-4">
-        <span class="hero-tagline">{article.category}</span>
-        <h1 class="font-display text-5xl text-white sm:text-6xl">{article.title}</h1>
+        <span class="hero-tagline">{post.data.category}</span>
+        <h1 class="font-display text-5xl text-white sm:text-6xl">{post.data.title}</h1>
         <div class="flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.3em] text-white/60">
-          <span>By {article.author}</span>
-          <span>{article.date}</span>
+          <span>By {post.data.author}</span>
+          <span>{formatDate(post.data.publishDate)}</span>
         </div>
       </div>
     </header>
 
     <div class="glass overflow-hidden rounded-[42px]">
-      <img src={article.image} alt={article.title} class="h-80 w-full object-cover" loading="lazy" />
+      <img src={post.data.heroImage} alt={post.data.heroImageAlt ?? post.data.title} class="h-80 w-full object-cover" loading="lazy" />
     </div>
 
     <!-- SLOT: post_top_strip -->
     <BannerSlot id="post_top_strip" />
 
     <div class="space-y-6 text-base leading-relaxed text-white/70">
-      <p class="first-letter:float-left first-letter:mr-4 first-letter:text-6xl first-letter:font-display first-letter:text-rose-gold first-letter:leading-none">
-  Luxury cam rooms are sculpted, not improvised. The way light kisses your cheekbones, the tempo of your intro story, the
-  cadence your mods keep in chat--it all tells viewers whether they have stumbled into something unforgettable.
-      </p>
-      <p>
-        Think of your room as a boutique hotel lobby. Every sensory element is intentional. Begin with a signature welcome ritual,
-        from a candle lighting to a velvet toast. Pair it with music that signals the tone of the night and reminders about your
-        premium offers. Energy rises when the room feels choreographed, not chaotic.
-      </p>
-      <!-- SLOT: post_inline_rect -->
-      <BannerSlot id="post_inline_rect" />
-      <p>
-        Once your baseline vibe is dialled in, layer conversion cues. Highlight goals visually in your overlays, coach mods to echo
-        them with warmth, and break the fourth wall with personal thank-you moments. Small details—slowing your voice, leaning into
-        the camera, smiling like you have a secret—make patrons feel like insiders.
-      </p>
-      <p>
-        Finally, close every show with a ritualistic sign-off. Share next-show teasers, invite VIPs to exclusive chats, and reinforce
-        that joining your fan club is the way to stay close. Luxury is never rushed; it is curated. Your audience will feel it and
-        reward you for it.
+      <Content />
+    </div>
+
+    <div class="content-card space-y-5">
+      <h2 class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Continue your launch</h2>
+      <div class="flex flex-col gap-3 sm:flex-row">
+        <a
+          class="inline-flex items-center justify-center gap-2 rounded-full border border-rose-gold/60 bg-rose-gold px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-midnight shadow-glow transition hover:-translate-y-1"
+          href={joinHref}
+          target={joinLinkTarget}
+          rel={joinLinkRel}
+        >
+          {joinCtaLabel}
+          {pagesBuild && <span aria-hidden="true">↗</span>}
+        </a>
+        <a
+          class="inline-flex items-center justify-center rounded-full border border-white/20 bg-transparent px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:-translate-y-1 hover:bg-white/10"
+          href={claimUrl}
+          target={claimLinkTarget}
+          rel={claimLinkRel}
+        >
+          Claim starter kit access
+          {claimLinkIsExternal && <span class="ml-2" aria-hidden="true">↗</span>}
+        </a>
+      </div>
+      <p class="text-xs text-white/50">
+        {claimLinkIsExternal
+          ? 'Pages preview links route to our secure external intake.'
+          : 'Production builds link directly to the secure /claim/ form.'}
       </p>
     </div>
   </article>
@@ -110,10 +108,11 @@ const { article, related } = Astro.props;
     <div class="grid gap-6 sm:grid-cols-3">
       {related.map((item) => (
         <a class="content-card space-y-3" href={withBase(`/blog/${item.slug}`)}>
-          <img src={item.image} alt={item.title} class="h-40 w-full rounded-3xl object-cover" loading="lazy" />
+          <img src={item.data.cardImage ?? item.data.heroImage} alt={item.data.heroImageAlt ?? item.data.title} class="h-40 w-full rounded-3xl object-cover" loading="lazy" />
           <div>
-            <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">{item.category}</p>
-            <p class="font-display text-xl text-white">{item.title}</p>
+            <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">{item.data.category}</p>
+            <p class="font-display text-xl text-white">{item.data.title}</p>
+            <p class="mt-1 text-xs uppercase tracking-[0.3em] text-white/40">{formatDate(item.data.publishDate)}</p>
           </div>
         </a>
       ))}

--- a/src/pages/starter-kit.astro
+++ b/src/pages/starter-kit.astro
@@ -1,5 +1,117 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
+import { getClaimUrl } from '../utils/links';
+
+const claimUrl = getClaimUrl();
+const claimLinkIsExternal = claimUrl.startsWith('http');
+const claimLinkTarget = claimLinkIsExternal ? '_blank' : undefined;
+const claimLinkRel = claimLinkIsExternal ? 'noreferrer' : undefined;
+
+const launchSchedule = [
+  { day: 'Day 1', focus: 'Account hygiene', actions: ['Secure passwords & 2FA', 'Upload payout documents', 'Submit tax forms'] },
+  { day: 'Day 2', focus: 'Persona calibration', actions: ['Define on-camera persona pillars', 'Curate three wardrobe looks', 'Draft room story statement'] },
+  { day: 'Day 3', focus: 'Lighting rehearsal', actions: ['Position key & fill lights', 'Set white balance presets', 'Capture screenshot for claim proof'] },
+  { day: 'Day 4', focus: 'Soft open rehearsal', actions: ['Run 20-minute private stream', 'Record self-review notes', 'Log mod feedback'] },
+  { day: 'Day 5', focus: 'Offer architecture', actions: ['Finalise tip menu ladder', 'Tag VIP incentives', 'Load custom emojis/overlays'] },
+  { day: 'Day 6', focus: 'Community priming', actions: ['Send teaser emails/DMs', 'Brief moderators with scripts', 'Schedule hero launch event'] },
+  { day: 'Day 7', focus: 'Signature launch show', actions: ['Run hero script', 'Showcase tiered incentives', 'Pin concierge tracking goal'] },
+  { day: 'Day 8', focus: 'Debrief & optimisation', actions: ['Review conversion metrics', 'Update lighting notes', 'Log top tippers & gifting cues'] },
+  { day: 'Day 9', focus: 'VIP nurture', actions: ['Send tailored DM check-ins', 'Record audio thank-yous', 'Invite VIPs to next stream'] },
+  { day: 'Day 10', focus: 'Momentum show', actions: ['Run VIP spotlight script', 'Introduce limited-time bundle', 'Capture highlight clips'] },
+  { day: 'Day 11', focus: 'Rest & analysis', actions: ['Audit chat transcripts', 'Update show pacing matrix', 'Refresh hydration & vocal care'] },
+  { day: 'Day 12', focus: 'Collaboration planning', actions: ['Confirm guest or mod co-host', 'Align boundaries & safe words', 'Prep shared tip goals'] },
+  { day: 'Day 13', focus: 'Theme night execution', actions: ['Run duet script variation', 'Upsell private experiences', 'Document fan reactions'] },
+  { day: 'Day 14', focus: 'Concierge debrief', actions: ['Submit claim follow-up notes', 'Review pricing ladder data', 'Lock next milestone target'] }
+];
+
+const lightingChecklist = [
+  {
+    heading: 'Prep the space',
+    items: [
+      'Dust surfaces and remove reflective clutter.',
+      'Close curtains and control stray sunlight before setup.',
+      'Place a neutral backdrop or fabric to avoid colour casts.'
+    ]
+  },
+  {
+    heading: 'Lighting placement',
+    items: [
+      'Position key light 45° from your face at eye level.',
+      'Bounce fill light off a wall to soften shadows.',
+      'Use a hair/rim light or LED strip to separate you from the background.'
+    ]
+  },
+  {
+    heading: 'Camera & colour',
+    items: [
+      'Lock white balance around 4,000–4,500K for warm luxury tones.',
+      'Set exposure so highlights stay below 90% to retain skin detail.',
+      'Test focus points seated and standing; mark floor positions with tape.'
+    ]
+  }
+];
+
+const tipMenu = [
+  { tier: 'Warm-up', tokens: '25–75', experience: 'Compliment spin, vibe check question, or reveal next show theme.' },
+  { tier: 'Momentum', tokens: '100–250', experience: 'Signature tease sequence, custom thank-you audio, or chat shout-out trio.' },
+  { tier: 'VIP', tokens: '300–600', experience: 'Five-minute private queue pass, exclusive photo drop, or priority mod attention.' },
+  { tier: 'Hero', tokens: '750+', experience: 'Concierge-scripted fantasy scene, collaborative goal unlock, or bespoke bundle.' }
+];
+
+const priceLadder = [
+  { label: 'Starter bundle', contents: 'Three-photo set + personalised welcome DM', price: '$19 / 190 tokens', cadence: 'Offer once per show during intro.' },
+  { label: 'VIP evening', contents: '15-min private + aftercare voice note', price: '$79 / 790 tokens', cadence: 'Promote after midpoint hype spike.' },
+  { label: 'Concierge circle', contents: 'Monthly membership + weekly DM check-ins', price: '$129 subscription', cadence: 'Pitch on closing nights with urgency.' },
+  { label: 'White-glove patron', contents: 'Monthly custom content + quarterly dinner date (virtual)', price: '$399 retainer', cadence: 'Reserved for trusted whales with direct mod vetting.' }
+];
+
+const showScripts = [
+  {
+    name: 'Hero Launch',
+    opening: '“Welcome to the first night of our concierge era. Take a deep breath with me and drop your name in chat so I can greet you properly.”',
+    middle: 'Layer your first two goals with sensory descriptors and invite mods to echo them every five minutes.',
+    closing: '“Before we slip away, bookmark tomorrow’s rendezvous and check DMs for your gratitude note.”'
+  },
+  {
+    name: 'VIP Spotlight',
+    opening: '“Tonight is for the insiders. Mods have the gold list ready—claim your glow if you want in.”',
+    middle: 'Highlight two VIP-only menu items and run a 10-minute storytelling arc anchored to them.',
+    closing: '“Mods will send your aftercare prompts. Whisper me if you need a custom send-off.”'
+  },
+  {
+    name: 'Collaboration Duet',
+    opening: '“We’re sharing the stage tonight. Show love to our guest and let’s choreograph the energy together.”',
+    middle: 'Switch POV every five minutes, narrating transitions so chat feels guided.',
+    closing: '“Tip ledger closes in three minutes—drop your finale requests now so we can honour them live.”'
+  }
+];
+
+const tosCheatsheet = [
+  {
+    platform: 'Bonga / BongaCash',
+    reminders: [
+      'No explicit mention of revenue guarantees in promos.',
+      'All referral links must live behind compliant landing pages.',
+      'Model verification screenshots must hide sensitive IDs before sharing.'
+    ]
+  },
+  {
+    platform: 'Chaturbate',
+    reminders: [
+      'Keep giveaway language compliant—use “thank-you reward” instead of “raffle”.',
+      'No off-platform payment handles in public chat; route to tip menu entries.',
+      'Age and identity statements must be read verbatim during debut shows.'
+    ]
+  },
+  {
+    platform: 'CamSoda',
+    reminders: [
+      'DM promotions require opt-in; use concierge templates for consent tracking.',
+      'Wardrobe slips should be treated as private content and never shared publicly.',
+      'All collaborations must be pre-approved with partner performer IDs on file.'
+    ]
+  }
+];
 ---
 
 <MainLayout
@@ -8,32 +120,139 @@ import MainLayout from '../layouts/MainLayout.astro';
 >
   <section class="content-card space-y-6">
     <span class="hero-tagline">Starter kit preview</span>
-    <h1 class="section-heading">Inside the free 14-day launch kit</h1>
-    <p class="text-sm text-white/70">
-      This page is a placeholder overview. After you verify your signup through our links, we email the complete bundle with downloadable files and editable templates.
+    <h1 class="font-display text-4xl text-white sm:text-5xl">Inside the free 14-day launch kit</h1>
+    <p class="max-w-2xl text-sm text-white/70">
+      Submit your signup proof and the concierge team delivers this entire playbook within one business day. Use it as a command centre for your launch runway or print it as a desk-side PDF using the export tool.
     </p>
+    <div class="flex flex-col gap-3 sm:flex-row">
+      <a
+        class="inline-flex items-center justify-center rounded-full border border-rose-gold/60 bg-rose-gold px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-midnight shadow-glow transition hover:-translate-y-1"
+        href={claimUrl}
+        target={claimLinkTarget}
+        rel={claimLinkRel}
+      >
+        Claim your starter kit
+        {claimLinkIsExternal && <span class="ml-2" aria-hidden="true">↗</span>}
+      </a>
+      <p class="text-xs uppercase tracking-[0.3em] text-white/45">
+        {claimLinkIsExternal
+          ? 'Pages preview links route to our secure Tally form.'
+          : 'Production builds open the secure PHP intake on /claim/.'}
+      </p>
+    </div>
   </section>
 
-  <section class="content-card space-y-4">
-    <h2 class="section-heading">What ships immediately</h2>
-    <ul class="grid gap-4 text-sm text-white/70 sm:grid-cols-2">
-      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Lighting checklist (home studio + travel)</li>
-      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Show script with 3 opening variations</li>
-      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Tip menu + upsell ladder matrix</li>
-      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">14-day schedule with daily focus prompts</li>
-      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Pricing ladder for tokens, tributes, and bundles</li>
-      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Terms of service cheatsheet with fast references</li>
-    </ul>
+  <section class="content-card space-y-6">
+    <h2 class="section-heading">14-day launch schedule</h2>
+    <div class="grid gap-4 md:grid-cols-2">
+      {launchSchedule.map((entry) => (
+        <div class="rounded-2xl border border-white/10 bg-white/5 p-5 backdrop-blur-xl">
+          <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-rose-petal/70">
+            <span>{entry.day}</span>
+            <span>{entry.focus}</span>
+          </div>
+          <ul class="mt-3 space-y-2 text-sm text-white/70">
+            {entry.actions.map((action) => (
+              <li>• {action}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
   </section>
 
-  <section class="content-card space-y-4 text-sm text-white/70">
-    <h2 class="section-heading">How to unlock it</h2>
-    <ol class="grid gap-4 sm:grid-cols-2">
-      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Join a paid platform through our affiliate rotator.</li>
-      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Send proof via screenshot or referral code.</li>
-      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Receive the starter kit email bundle instantly.</li>
-      <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">Ask follow-up questions any time during the 14-day runway.</li>
-    </ol>
+  <section class="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+    <div class="content-card space-y-5">
+      <h2 class="section-heading">Lighting checklist</h2>
+      <div class="space-y-4 text-sm text-white/70">
+        {lightingChecklist.map((section) => (
+          <div class="rounded-2xl border border-white/10 bg-white/5 p-5 backdrop-blur-xl">
+            <h3 class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">{section.heading}</h3>
+            <ul class="mt-3 space-y-2">
+              {section.items.map((item) => (
+                <li>• {item}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+    <div class="content-card space-y-5">
+      <h2 class="section-heading">Tip menu foundations</h2>
+      <table class="w-full text-left text-sm text-white/70">
+        <thead class="text-xs uppercase tracking-[0.35em] text-white/50">
+          <tr>
+            <th class="pb-2">Tier</th>
+            <th class="pb-2">Tokens</th>
+            <th class="pb-2">Experience</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-white/10">
+          {tipMenu.map((item) => (
+            <tr class="align-top">
+              <td class="py-3 pr-4 font-semibold text-white">{item.tier}</td>
+              <td class="py-3 pr-4">{item.tokens}</td>
+              <td class="py-3">{item.experience}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="content-card space-y-6">
+    <h2 class="section-heading">Price ladder examples</h2>
+    <div class="grid gap-4 md:grid-cols-2">
+      {priceLadder.map((offer) => (
+        <div class="rounded-2xl border border-white/10 bg-white/5 p-5 backdrop-blur-xl">
+          <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">{offer.label}</p>
+          <p class="mt-2 font-semibold text-white">{offer.contents}</p>
+          <p class="mt-2 text-sm text-white/70">{offer.price}</p>
+          <p class="mt-3 text-xs uppercase tracking-[0.3em] text-white/40">{offer.cadence}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section class="content-card space-y-6">
+    <h2 class="section-heading">Show script capsules</h2>
+    <div class="grid gap-4 md:grid-cols-3">
+      {showScripts.map((script) => (
+        <div class="rounded-2xl border border-white/10 bg-white/5 p-5 backdrop-blur-xl">
+          <h3 class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">{script.name}</h3>
+          <dl class="mt-3 space-y-3 text-sm text-white/70">
+            <div>
+              <dt class="font-semibold text-white">Opening cue</dt>
+              <dd class="mt-1">{script.opening}</dd>
+            </div>
+            <div>
+              <dt class="font-semibold text-white">Mid-show focus</dt>
+              <dd class="mt-1">{script.middle}</dd>
+            </div>
+            <div>
+              <dt class="font-semibold text-white">Closing ritual</dt>
+              <dd class="mt-1">{script.closing}</dd>
+            </div>
+          </dl>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section class="content-card space-y-6">
+    <h2 class="section-heading">Terms of service cheatsheet</h2>
+    <div class="grid gap-4 md:grid-cols-3">
+      {tosCheatsheet.map((block) => (
+        <div class="rounded-2xl border border-white/10 bg-white/5 p-5 backdrop-blur-xl">
+          <h3 class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">{block.platform}</h3>
+          <ul class="mt-3 space-y-2 text-sm text-white/70">
+            {block.reminders.map((note) => (
+              <li>• {note}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
   </section>
 
   <section class="content-card space-y-4 text-xs uppercase tracking-[0.3em] text-white/55">
@@ -42,4 +261,49 @@ import MainLayout from '../layouts/MainLayout.astro';
     <p>Accounts remain yours; you can leave anytime.</p>
     <p>Affiliate links fund the starter kit.</p>
   </section>
+
+  <style>
+    @media print {
+      :global(body) {
+        background: #ffffff !important;
+        color: #111111 !important;
+        font-family: 'Inter', system-ui, sans-serif;
+      }
+
+      :global(main) {
+        background: transparent !important;
+        box-shadow: none !important;
+      }
+
+      :global(.content-card) {
+        background: #ffffff !important;
+        border: 1px solid #d0d0d0 !important;
+        color: #111111 !important;
+        box-shadow: none !important;
+      }
+
+      :global(.content-card a) {
+        color: #111111 !important;
+        text-decoration: underline;
+      }
+
+      :global(.content-card .text-white\/70),
+      :global(.content-card .text-white\/65),
+      :global(.content-card .text-white\/55),
+      :global(.content-card .text-white\/50),
+      :global(.content-card .text-white\/40) {
+        color: #333333 !important;
+      }
+
+      :global(.hero-shell),
+      :global(.shadow-glow) {
+        box-shadow: none !important;
+      }
+
+      :global(a[href^="http"])::after {
+        content: ' (' attr(href) ')';
+        font-size: 0.8em;
+      }
+    }
+  </style>
 </MainLayout>


### PR DESCRIPTION
## Summary
- add starter kit claim guard, print-friendly starter kit overview, and build automation for ViceTemple bundles
- seed four recruiting-focused blog posts powered by new content collection and update blog surfaces to pull from Markdown
- harden claim uploads, add export tooling, and refresh CI workflow to keep Pages artifacts PHP-free

## Pages URL
- https://leecuevasowner.github.io/naughtycamspot/

## Screenshots
- /claim
  ![Claim page](browser:/invocations/jmwrgkwp/artifacts/artifacts/claim.png)
- /starter-kit
  ![Starter kit](browser:/invocations/afnffovk/artifacts/artifacts/starter-kit.png)
- Blog post
  ![CamSoda vs. Chaturbate blog post](browser:/invocations/wnbvdchp/artifacts/artifacts/blog-post.png)

## Notes
- GitHub Pages builds keep the external Tally claim form and strip `/go` redirectors; ViceTemple uses the PHP flow for `/claim/`.


------
https://chatgpt.com/codex/tasks/task_e_68f2dde1286c832698aec1e89d83431a