### PR TITLE
Adjust package-lock for npm ci compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "naughtycamspot",
   "version": "1.0.0",
-  "lockfileVersion": 3,
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {


### PR DESCRIPTION
## Summary
- update the repository lockfile to use lockfileVersion 2 so npm ci accepts it

## Testing
- not run (npm install requires network access)


------
https://chatgpt.com/codex/tasks/task_e_68f2e1fcb3a08326b7996b5eb075578b