### PR TITLE
feat: slim header nav with More menu

### DIFF
--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -1,0 +1,15 @@
+export const NAV_PRIMARY = [
+  { href: '/', label: 'Home' },
+  { href: '/compare', label: 'Compare' },
+  { href: '/recommend', label: 'Recommend' },
+  { href: '/earnings', label: 'Earnings' },
+  { href: '/blog', label: 'Blog' }
+];
+
+export const NAV_MORE = [
+  { href: '/contests', label: 'Contests' },
+  { href: '/models', label: 'Models' },
+  { href: '/starter-kit', label: 'Starter Kit' },
+  { href: '/join-models', label: 'Join Models' },
+  { href: '/claim', label: 'Claim' }
+];

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -5,6 +5,7 @@ const {
   showNavigation = true
 } = Astro.props;
 import '../styles/tailwind.css';
+import { NAV_MORE, NAV_PRIMARY } from '../data/nav';
 import { buildTrackedLink, withBase } from '../utils/links';
 
 const isPagesBuild = import.meta.env.IS_PAGES === 'true';
@@ -47,24 +48,24 @@ const navCtaHref = buildTrackedLink({
   placeholder: HERO_CTA_PLACEHOLDER
 });
 
-const navLinks = [
-  { href: '/', label: 'Home' },
-  { href: '/compare', label: 'Compare' },
-  { href: '/recommend', label: 'Recommend' },
-  { href: '/earnings', label: 'Earnings' },
-  { href: '/contests', label: 'Contests' },
-  { href: '/starter-kit', label: 'Starter Kit' },
-  { href: '/join', label: 'Join' },
-  { href: '/blog', label: 'Blog' },
-  { href: '/about', label: 'About' },
-  { href: '/contact', label: 'Contact' },
-  { href: '/models/anna-prince', label: 'Example model page' }
-];
+const currentPath = Astro.url.pathname.replace(/\/+$/, '') || '/';
+
+const isNavActive = (href: string) => {
+  const normalizedHref = href.replace(/\/+$/, '') || '/';
+  if (normalizedHref === '/') {
+    return currentPath === '/';
+  }
+  return currentPath === normalizedHref || currentPath.startsWith(`${normalizedHref}/`);
+};
+
+const moreMenuActive = NAV_MORE.some((link) => isNavActive(link.href));
 
 const footerLinks = [
-  { href: '/privacy', label: 'Privacy Policy' },
+  ...NAV_MORE,
+  { href: '/about', label: 'About' },
+  { href: '/privacy', label: 'Privacy' },
   { href: '/terms', label: 'Terms' },
-  { href: '/disclosure', label: 'Affiliate Disclosure' }
+  { href: '/contact', label: 'Contact' }
 ];
 
 const mainTopPadding = showNavigation ? 'pt-10' : 'pt-20';
@@ -103,36 +104,147 @@ gtag('config', '${gaMeasurementId}');`}
 
     <div class="relative z-10 flex min-h-screen flex-col">
       {showNavigation && (
-        <header class="mx-auto flex w-full max-w-6xl flex-col gap-5 px-6 pt-10 lg:flex-row lg:items-center lg:justify-between lg:gap-6">
+        <header class="mx-auto flex w-full max-w-6xl flex-col gap-5 px-6 pt-10 lg:flex-row lg:items-center lg:justify-between lg:gap-6" data-site-nav>
           <div class="flex w-full items-center justify-between gap-3">
             <a
               href={withBase('/')}
-              class="flex items-center gap-3 text-sm font-semibold tracking-[0.32em] text-rose-gold uppercase"
+              class="flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.32em] text-rose-gold"
             >
               <span class="flex h-11 w-11 items-center justify-center rounded-full border border-rose-gold/60 bg-white/10 shadow-glow backdrop-blur-lg">
                 N
               </span>
               NaughtyCamSpot
             </a>
-            <a
-              class="rounded-full border border-rose-gold/40 bg-rose-gold/20 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-petal shadow-glow backdrop-blur-xl transition hover:border-rose-gold/60 hover:bg-rose-gold/30"
-              href={navCtaHref}
-              target="_blank"
-              rel="noreferrer"
-              data-track={shouldTrackClicks ? 'click' : undefined}
-              data-slot={shouldTrackClicks ? navCtaSlot : undefined}
-              data-camp={shouldTrackClicks ? navCtaCamp : undefined}
-            >
-              Start camming • Free starter kit
-            </a>
-          </div>
-          <nav class="flex w-full flex-wrap items-center justify-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-3 text-[0.65rem] uppercase tracking-[0.25em] text-white/70 backdrop-blur-2xl sm:gap-4 sm:text-[0.7rem] sm:tracking-[0.28em] lg:flex-nowrap lg:text-sm lg:tracking-[0.3em]">
-            {navLinks.map((link) => (
-              <a class="whitespace-nowrap transition hover:text-rose-gold" href={withBase(link.href)}>
-                {link.label}
+            <div class="flex items-center gap-3">
+              <button
+                type="button"
+                class="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/70 shadow-glow backdrop-blur-xl transition hover:border-white/30 hover:text-rose-gold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-gold lg:hidden"
+                data-nav-mobile-toggle
+                aria-expanded="false"
+                aria-controls="mobile-navigation"
+              >
+                Menu
+              </button>
+              <a
+                class="rounded-full border border-rose-gold/40 bg-rose-gold/20 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-petal shadow-glow backdrop-blur-xl transition hover:border-rose-gold/60 hover:bg-rose-gold/30"
+                href={navCtaHref}
+                target="_blank"
+                rel="noreferrer"
+                data-track={shouldTrackClicks ? 'click' : undefined}
+                data-slot={shouldTrackClicks ? navCtaSlot : undefined}
+                data-camp={shouldTrackClicks ? navCtaCamp : undefined}
+              >
+                Start camming • Free starter kit
               </a>
-            ))}
+            </div>
+          </div>
+          <nav class="hidden w-full items-center justify-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-3 text-[0.65rem] uppercase tracking-[0.25em] text-white/70 backdrop-blur-2xl sm:gap-4 sm:text-[0.7rem] sm:tracking-[0.28em] lg:flex lg:flex-nowrap lg:text-sm lg:tracking-[0.3em]" aria-label="Primary">
+            {NAV_PRIMARY.map((link) => {
+              const active = isNavActive(link.href);
+              return (
+                <a
+                  class={`whitespace-nowrap transition hover:text-rose-gold ${active ? 'text-rose-gold' : ''}`}
+                  href={withBase(link.href)}
+                  aria-current={active ? 'page' : undefined}
+                >
+                  {link.label}
+                </a>
+              );
+            })}
+            <div class="relative" data-nav-more>
+              <button
+                type="button"
+                class={`flex items-center gap-2 whitespace-nowrap rounded-full border border-transparent px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.25em] transition hover:text-rose-gold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-gold lg:text-sm lg:tracking-[0.3em] ${moreMenuActive ? 'text-rose-gold' : 'text-white/70'}`}
+                data-nav-more-trigger
+                aria-haspopup="menu"
+                aria-expanded="false"
+              >
+                More
+              </button>
+              <div
+                class="pointer-events-none invisible absolute right-0 top-full mt-3 w-56 origin-top-right rounded-3xl border border-white/10 bg-black/90 p-3 opacity-0 shadow-glow backdrop-blur-2xl transition [--menu-duration:150ms]"
+                data-nav-more-panel
+                role="menu"
+              >
+                <ul class="flex flex-col gap-2 text-[0.65rem] uppercase tracking-[0.25em] text-white/70 lg:text-xs lg:tracking-[0.28em]">
+                  {NAV_MORE.map((link) => (
+                    <li>
+                      <a
+                        class="block rounded-full px-4 py-2 transition hover:bg-white/10 hover:text-rose-gold"
+                        href={withBase(link.href)}
+                        role="menuitem"
+                      >
+                        {link.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
           </nav>
+          <div class="lg:hidden">
+            <div
+              class="fixed inset-0 z-40 hidden bg-black/70 opacity-0 transition-opacity duration-200"
+              data-nav-mobile-overlay
+            ></div>
+            <div
+              id="mobile-navigation"
+              class="fixed inset-y-0 right-0 z-50 flex w-80 max-w-full translate-x-full flex-col gap-6 bg-black/95 p-6 text-sm uppercase tracking-[0.32em] text-white/70 shadow-glow transition-transform duration-200"
+              data-nav-mobile-drawer
+            >
+              <div class="flex items-center justify-between">
+                <span class="text-xs font-semibold tracking-[0.28em] text-white/60">Navigation</span>
+                <button
+                  type="button"
+                  class="rounded-full border border-white/20 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.25em] text-white/70 transition hover:border-white/30 hover:text-rose-gold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-gold"
+                  data-nav-mobile-close
+                  aria-label="Close menu"
+                >
+                  Close
+                </button>
+              </div>
+              <nav class="flex flex-col gap-3 text-white/70" aria-label="Mobile primary">
+                {NAV_PRIMARY.map((link) => {
+                  const active = isNavActive(link.href);
+                  return (
+                    <a
+                      class={`rounded-full border border-white/10 px-4 py-3 text-[0.65rem] tracking-[0.28em] transition hover:border-white/20 hover:text-rose-gold ${active ? 'border-rose-gold/50 text-rose-gold' : 'text-white/70'}`}
+                      href={withBase(link.href)}
+                      data-nav-mobile-link
+                      aria-current={active ? 'page' : undefined}
+                    >
+                      {link.label}
+                    </a>
+                  );
+                })}
+              </nav>
+              <div class="flex flex-col gap-3" data-nav-mobile-more>
+                <button
+                  type="button"
+                  class={`flex items-center justify-between rounded-full border px-4 py-3 text-[0.65rem] tracking-[0.28em] transition hover:border-white/20 hover:text-rose-gold ${moreMenuActive ? 'border-rose-gold/50 text-rose-gold' : 'border-white/10 text-white/70'}`}
+                  data-nav-mobile-more-trigger
+                  aria-expanded="false"
+                >
+                  <span>More</span>
+                  <span aria-hidden="true">▾</span>
+                </button>
+                <div class="hidden flex-col gap-2 text-[0.65rem] tracking-[0.28em] text-white/70" data-nav-mobile-more-panel>
+                  {NAV_MORE.map((link) => {
+                    const active = isNavActive(link.href);
+                    return (
+                      <a
+                        class={`rounded-full border border-white/10 px-4 py-3 transition hover:border-white/20 hover:text-rose-gold ${active ? 'border-rose-gold/50 text-rose-gold' : 'text-white/70'}`}
+                        href={withBase(link.href)}
+                        data-nav-mobile-link
+                      >
+                        {link.label}
+                      </a>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          </div>
         </header>
       )}
 
@@ -158,6 +270,191 @@ gtag('config', '${gaMeasurementId}');`}
         </div>
       </footer>
     </div>
+    {showNavigation && (
+      <script is:inline>
+        {`(function(){
+  const navRoot = document.querySelector('[data-site-nav]');
+  if (!navRoot) {
+    return;
+  }
+
+  const moreContainer = navRoot.querySelector('[data-nav-more]');
+  const moreButton = moreContainer ? moreContainer.querySelector('[data-nav-more-trigger]') : null;
+  const morePanel = moreContainer ? moreContainer.querySelector('[data-nav-more-panel]') : null;
+  const moreLinks = morePanel ? morePanel.querySelectorAll('a[href]') : null;
+  const mobileToggle = navRoot.querySelector('[data-nav-mobile-toggle]');
+  const mobileDrawer = navRoot.querySelector('[data-nav-mobile-drawer]');
+  const mobileOverlay = navRoot.querySelector('[data-nav-mobile-overlay]');
+  const mobileClose = navRoot.querySelector('[data-nav-mobile-close]');
+  const mobileLinks = navRoot.querySelectorAll('[data-nav-mobile-link]');
+  const mobileMoreTrigger = navRoot.querySelector('[data-nav-mobile-more-trigger]');
+  const mobileMorePanel = navRoot.querySelector('[data-nav-mobile-more-panel]');
+
+  let moreOpen = false;
+  let drawerOpen = false;
+  let mobileMoreOpen = false;
+  let moreHoverTimer = null;
+
+  const setMoreOpen = (open) => {
+    if (!moreButton || !morePanel) {
+      return;
+    }
+    if (moreOpen === open) {
+      return;
+    }
+    moreOpen = open;
+    moreButton.setAttribute('aria-expanded', open ? 'true' : 'false');
+    if (open) {
+      morePanel.classList.remove('pointer-events-none');
+      morePanel.classList.remove('invisible');
+      window.requestAnimationFrame(() => {
+        morePanel.classList.remove('opacity-0');
+      });
+    } else {
+      morePanel.classList.add('pointer-events-none');
+      morePanel.classList.add('opacity-0');
+      window.setTimeout(() => {
+        if (!moreOpen) {
+          morePanel.classList.add('invisible');
+        }
+      }, 150);
+    }
+  };
+
+  const closeMore = () => setMoreOpen(false);
+
+  const handleDocumentClick = (event) => {
+    if (!moreOpen || !moreContainer) {
+      return;
+    }
+    if (moreContainer.contains(event.target)) {
+      return;
+    }
+    closeMore();
+  };
+
+  const handleEscape = (event) => {
+    if (event.key !== 'Escape') {
+      return;
+    }
+    if (moreOpen) {
+      closeMore();
+    }
+    if (drawerOpen) {
+      setDrawerOpen(false);
+    }
+  };
+
+  const setDrawerOpen = (open) => {
+    if (!mobileDrawer || !mobileOverlay) {
+      return;
+    }
+    if (drawerOpen === open) {
+      return;
+    }
+    drawerOpen = open;
+    if (mobileToggle) {
+      mobileToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+    if (open) {
+      mobileOverlay.classList.remove('hidden');
+      mobileOverlay.classList.add('opacity-0');
+      window.requestAnimationFrame(() => {
+        mobileOverlay.classList.remove('opacity-0');
+        mobileOverlay.classList.add('opacity-100');
+        mobileDrawer.classList.remove('translate-x-full');
+      });
+      document.body.classList.add('overflow-hidden');
+    } else {
+      mobileOverlay.classList.remove('opacity-100');
+      mobileOverlay.classList.add('opacity-0');
+      mobileDrawer.classList.add('translate-x-full');
+      document.body.classList.remove('overflow-hidden');
+      window.setTimeout(() => {
+        if (!drawerOpen) {
+          mobileOverlay.classList.add('hidden');
+        }
+      }, 200);
+    }
+  };
+
+  const setMobileMoreOpen = (open) => {
+    if (!mobileMoreTrigger || !mobileMorePanel) {
+      return;
+    }
+    mobileMoreOpen = open;
+    mobileMoreTrigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+    if (open) {
+      mobileMorePanel.classList.remove('hidden');
+    } else {
+      mobileMorePanel.classList.add('hidden');
+    }
+  };
+
+  if (moreButton && morePanel) {
+    moreButton.addEventListener('click', () => {
+      setMoreOpen(!moreOpen);
+    });
+    if (moreContainer) {
+      const openOnHover = () => {
+        window.clearTimeout(moreHoverTimer);
+        setMoreOpen(true);
+      };
+      const closeOnLeave = () => {
+        window.clearTimeout(moreHoverTimer);
+        moreHoverTimer = window.setTimeout(() => {
+          setMoreOpen(false);
+        }, 100);
+      };
+      moreContainer.addEventListener('mouseenter', openOnHover);
+      moreContainer.addEventListener('mouseleave', closeOnLeave);
+    }
+    document.addEventListener('click', handleDocumentClick);
+    if (moreLinks && moreLinks.length > 0) {
+      moreLinks.forEach((link) => {
+        link.addEventListener('click', closeMore);
+      });
+    }
+  }
+
+  if (mobileToggle) {
+    mobileToggle.addEventListener('click', () => {
+      setDrawerOpen(!drawerOpen);
+    });
+  }
+
+  if (mobileOverlay) {
+    mobileOverlay.addEventListener('click', () => setDrawerOpen(false));
+  }
+
+  if (mobileClose) {
+    mobileClose.addEventListener('click', () => setDrawerOpen(false));
+  }
+
+  if (mobileLinks && mobileLinks.length > 0) {
+    mobileLinks.forEach((link) => {
+      link.addEventListener('click', () => setDrawerOpen(false));
+    });
+  }
+
+  if (mobileMoreTrigger) {
+    mobileMoreTrigger.addEventListener('click', () => {
+      setMobileMoreOpen(!mobileMoreOpen);
+    });
+  }
+
+  const handleResize = () => {
+    if (window.innerWidth >= 1024) {
+      setDrawerOpen(false);
+      document.body.classList.remove('overflow-hidden');
+    }
+  };
+
+  window.addEventListener('keydown', handleEscape);
+  window.addEventListener('resize', handleResize);
+})();`}
+      </script>
+    )}
     {shouldTrackClicks && (
       <script is:inline>
         {`(function(){


### PR DESCRIPTION
## Summary
- introduce structured navigation data for primary and overflow links
- rebuild the header to surface five links with a More dropdown plus mobile drawer
- refresh the footer to surface More destinations alongside key legal pages

## Testing
- npm run build

## Screenshots

### Desktop
**Before**
![Before desktop](browser:/invocations/sqppkdei/artifacts/artifacts/before-desktop.png)

**After**
![After desktop](browser:/invocations/qwgyharl/artifacts/artifacts/after-desktop.png)

### Mobile
**Before**
![Before mobile](browser:/invocations/qahiwnou/artifacts/artifacts/before-mobile.png)

**After**
![After mobile](browser:/invocations/npvwftoh/artifacts/artifacts/after-mobile.png)


------
https://chatgpt.com/codex/tasks/task_e_68f31f14459c83268a65b3ce8f7b6ee1