### PR TITLE
hotfix: slim header nav with More menu

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -165,6 +165,7 @@ gtag('config', '${gaMeasurementId}');`}
                 class="pointer-events-none invisible absolute right-0 top-full mt-3 w-56 origin-top-right rounded-3xl border border-white/10 bg-black/90 p-3 opacity-0 shadow-glow backdrop-blur-2xl transition [--menu-duration:150ms]"
                 data-nav-more-panel
                 role="menu"
+                tabindex="-1"
               >
                 <ul class="flex flex-col gap-2 text-[0.65rem] uppercase tracking-[0.25em] text-white/70 lg:text-xs lg:tracking-[0.28em]">
                   {NAV_MORE.map((link) => (
@@ -281,7 +282,7 @@ gtag('config', '${gaMeasurementId}');`}
   const moreContainer = navRoot.querySelector('[data-nav-more]');
   const moreButton = moreContainer ? moreContainer.querySelector('[data-nav-more-trigger]') : null;
   const morePanel = moreContainer ? moreContainer.querySelector('[data-nav-more-panel]') : null;
-  const moreLinks = morePanel ? morePanel.querySelectorAll('a[href]') : null;
+  const moreLinks = morePanel ? Array.from(morePanel.querySelectorAll('a[href]')) : [];
   const mobileToggle = navRoot.querySelector('[data-nav-mobile-toggle]');
   const mobileDrawer = navRoot.querySelector('[data-nav-mobile-drawer]');
   const mobileOverlay = navRoot.querySelector('[data-nav-mobile-overlay]');
@@ -294,6 +295,53 @@ gtag('config', '${gaMeasurementId}');`}
   let drawerOpen = false;
   let mobileMoreOpen = false;
   let moreHoverTimer = null;
+
+  const getMoreFocusable = () => {
+    if (!morePanel) {
+      return [];
+    }
+    return Array.from(
+      morePanel.querySelectorAll(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+    );
+  };
+
+  const focusMoreFirstItem = () => {
+    if (!moreButton || document.activeElement !== moreButton) {
+      return;
+    }
+    const focusable = getMoreFocusable();
+    if (focusable.length > 0) {
+      focusable[0].focus();
+      return;
+    }
+    if (morePanel) {
+      morePanel.focus();
+    }
+  };
+
+  const handleMoreKeydown = (event) => {
+    if (event.key !== 'Tab') {
+      return;
+    }
+    const focusable = getMoreFocusable();
+    if (focusable.length === 0) {
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    if (event.shiftKey) {
+      if (active === first) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
 
   const setMoreOpen = (open) => {
     if (!moreButton || !morePanel) {
@@ -310,6 +358,8 @@ gtag('config', '${gaMeasurementId}');`}
       window.requestAnimationFrame(() => {
         morePanel.classList.remove('opacity-0');
       });
+      focusMoreFirstItem();
+      morePanel.addEventListener('keydown', handleMoreKeydown);
     } else {
       morePanel.classList.add('pointer-events-none');
       morePanel.classList.add('opacity-0');
@@ -318,6 +368,11 @@ gtag('config', '${gaMeasurementId}');`}
           morePanel.classList.add('invisible');
         }
       }, 150);
+      morePanel.removeEventListener('keydown', handleMoreKeydown);
+      const active = document.activeElement;
+      if (active && (active === moreButton || (morePanel && morePanel.contains(active)))) {
+        moreButton.focus({ preventScroll: true });
+      }
     }
   };
 
@@ -342,6 +397,19 @@ gtag('config', '${gaMeasurementId}');`}
     }
     if (drawerOpen) {
       setDrawerOpen(false);
+    }
+  };
+
+  const setMobileMoreOpen = (open) => {
+    if (!mobileMoreTrigger || !mobileMorePanel) {
+      return;
+    }
+    mobileMoreOpen = open;
+    mobileMoreTrigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+    if (open) {
+      mobileMorePanel.classList.remove('hidden');
+    } else {
+      mobileMorePanel.classList.add('hidden');
     }
   };
 
@@ -375,19 +443,16 @@ gtag('config', '${gaMeasurementId}');`}
           mobileOverlay.classList.add('hidden');
         }
       }, 200);
-    }
-  };
-
-  const setMobileMoreOpen = (open) => {
-    if (!mobileMoreTrigger || !mobileMorePanel) {
-      return;
-    }
-    mobileMoreOpen = open;
-    mobileMoreTrigger.setAttribute('aria-expanded', open ? 'true' : 'false');
-    if (open) {
-      mobileMorePanel.classList.remove('hidden');
-    } else {
-      mobileMorePanel.classList.add('hidden');
+      setMobileMoreOpen(false);
+      const active = document.activeElement;
+      if (
+        active &&
+        mobileMoreTrigger &&
+        mobileDrawer &&
+        mobileDrawer.contains(active)
+      ) {
+        mobileMoreTrigger.focus({ preventScroll: true });
+      }
     }
   };
 
@@ -410,7 +475,7 @@ gtag('config', '${gaMeasurementId}');`}
       moreContainer.addEventListener('mouseleave', closeOnLeave);
     }
     document.addEventListener('click', handleDocumentClick);
-    if (moreLinks && moreLinks.length > 0) {
+    if (moreLinks.length > 0) {
       moreLinks.forEach((link) => {
         link.addEventListener('click', closeMore);
       });


### PR DESCRIPTION
## Summary
- render the header navigation from the new nav data and add a More dropdown with aria markup and focus management
- mirror the nav changes inside the mobile drawer with a collapsible More section and shared link handling
- update the footer to consume the shared More links alongside the legal links

## Testing
- npm test *(fails: `npx astro build` cannot download dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f32bb556a0832686d49d35e966eaa4