### PR TITLE
feat: enable BongaCams (programs.json + /go rotator)

### DIFF
--- a/public/go/affiliates.php
+++ b/public/go/affiliates.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 const GO_SUBID_PARAM = 'subid';
 const GO_MODEL_PROGRAM_CONFIG = [
     'bonga' => [
-        'active' => false,
+        'active' => true,
         'tiers' => ['T1', 'T2', 'T3', 'T4'],
     ],
     'camsoda' => [
@@ -185,23 +185,19 @@ function go_model_fallback_url(string $subid): string
     return go_append_subid('/join-models/', $subid);
 }
 
-/**
- * BongaCash model signup targets segmented by tier.
- * These will need to be replaced with live tracking links once issued.
- */
 function go_build_bonga_model_signup(string $subid, array $context = []): string
 {
-    $tier = strtoupper($context['tier'] ?? 'T4');
-    $targets = [
-        'T1' => 'https://track.naughtycamspot.com/bonga/models/tier1',
-        'T2' => 'https://track.naughtycamspot.com/bonga/models/tier2',
-        'T3' => 'https://track.naughtycamspot.com/bonga/models/tier3',
-        'T4' => 'https://track.naughtycamspot.com/bonga/models/global',
-    ];
+    // TODO: if panel uses a different subid key, change here and in programs.json
+    $subKey = 's1';
 
-    $base = $targets[$tier] ?? $targets['T4'];
+    // Single base for now; if you get tier-specific refs, branch on $tier
+    $base = 'https://bongacash.com/model-ref?c=828873';
 
-    return go_append_subid($base, $subid);
+    // Append subid
+    $sep = (strpos($base, '?') === false) ? '?' : '&';
+    $url = $base . $sep . $subKey . '=' . rawurlencode($subid);
+
+    return $url;
 }
 
 function go_build_camsoda_model_signup(string $subid): string

--- a/src/data/programs.json
+++ b/src/data/programs.json
@@ -26,13 +26,13 @@
   {
     "key": "bonga",
     "name": "BongaCams",
-    "join_base": "TBD",
-    "subid_params": ["TBD"],
+    "join_base": "https://bongacash.com/model-ref?c=828873",
+    "subid_params": ["s1"],
     "payout": "weekly",
     "kyc": "medium",
     "traffic": "high EU/EE",
     "geo": "T1–T4 bounty tiers",
     "best_for": ["GEO-tuned payouts"],
-    "status": "pending"
+    "status": "approved"
   }
 ]


### PR DESCRIPTION
## Summary
- set the BongaCams program to use https://bongacash.com/model-ref?c=828873 with provisional s1 subid handling and mark it approved for onboarding tools
- enable the Bonga model rotator with the same base link and s1 tracking parameter across all bounty tiers while preserving existing redirect caching rules
- Pages builds continue to use the direct join_base so static outputs avoid /go/ paths while production can still route via the rotator

## Testing
- npm run build:pages
- rg --color=never -o "https://bongacash.com/model-ref\?c=828873" dist/compare/index.html
- rg --color=never -o "/go/" dist -g"*.html"

## Post-deploy
- curl -I "https://naughtycamspot.com/go/model-join.php?src=test&camp=home&date=20251018&cc=US"
- curl -I "https://naughtycamspot.com/go/model-join.php?src=test&camp=home&date=20251018&cc=DE"
- curl -I "https://naughtycamspot.com/go/model-join.php?src=test&camp=home&date=20251018&cc=BR"

------
https://chatgpt.com/codex/tasks/task_e_68f46311f17c8326a435591515b26073