### PR TITLE
feat: route all generic CTAs to /startright (Pages-safe)

### DIFF
--- a/src/data/banners.ts
+++ b/src/data/banners.ts
@@ -4,7 +4,7 @@ export const BANNERS = {
   home_top_leaderboard: {
     img: '/ads/leaderboard-970x90.svg',
     alt: 'Start camming — get the free 14-day kit',
-    href_pages: 'https://www.camsoda.com/models',
+    href_pages: '/startright',
     href_prod: '/go/model-join.php?src=banner_home_top&camp=home&date=YYYYMMDD',
     size: { w: 970, h: 90 },
     note: DISCLOSURE
@@ -12,7 +12,7 @@ export const BANNERS = {
   model_sidebar_tall: {
     img: '/ads/sky-160x600.svg',
     alt: 'Join with our links',
-    href_pages: 'https://www.camsoda.com/models',
+    href_pages: '/startright',
     href_prod: '/go/model-join.php?src=banner_model_sidebar&camp=model&date=YYYYMMDD',
     size: { w: 160, h: 600 },
     note: DISCLOSURE
@@ -20,7 +20,7 @@ export const BANNERS = {
   post_inline_rect: {
     img: '/ads/rect-300x250.svg',
     alt: 'Claim your starter kit',
-    href_pages: '/claim',
+    href_pages: '/startright',
     href_prod: '/claim/',
     size: { w: 300, h: 250 },
     note: 'Free 14-day kit after signup proof.'

--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -1,4 +1,11 @@
-export const NAV_PRIMARY = [
+export type NavLink = {
+  href: string;
+  label: string;
+  pagesHref?: string;
+  prodHref?: string;
+};
+
+export const NAV_PRIMARY: NavLink[] = [
   { href: '/', label: 'Home' },
   { href: '/compare', label: 'Compare' },
   { href: '/startright', label: 'StartRight' },
@@ -6,10 +13,10 @@ export const NAV_PRIMARY = [
   { href: '/blog', label: 'Blog' }
 ];
 
-export const NAV_MORE = [
+export const NAV_MORE: NavLink[] = [
   { href: '/contests', label: 'Contests' },
   { href: '/models', label: 'Models' },
   { href: '/starter-kit', label: 'Starter Kit' },
-  { href: '/join-models', label: 'Join Models' },
+  { href: '/startright', label: 'Join Models', prodHref: '/join-models' },
   { href: '/claim', label: 'Claim' }
 ];

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -10,7 +10,9 @@ import { PRIMARY_CTA } from '../data/copy';
 import { NAV_MORE, NAV_PRIMARY } from '../data/nav';
 import { withBase } from '../utils/links';
 
-const isPagesBuild = import.meta.env.IS_PAGES === 'true';
+const baseUrl = typeof import.meta.env.BASE_URL === 'string' ? import.meta.env.BASE_URL : '/';
+const isPagesFlag = typeof import.meta.env.IS_PAGES === 'string' ? import.meta.env.IS_PAGES === 'true' : false;
+const isPagesBuild = isPagesFlag || baseUrl !== '/';
 
 const resolveHostname = (value) => {
   if (!value) {
@@ -49,7 +51,17 @@ const isNavActive = (href: string) => {
   return currentPath === normalizedHref || currentPath.startsWith(`${normalizedHref}/`);
 };
 
-const moreMenuActive = NAV_MORE.some((link) => isNavActive(link.href));
+const resolveNavHref = (link) => {
+  if (isPagesBuild && typeof link.pagesHref === 'string') {
+    return link.pagesHref;
+  }
+  if (!isPagesBuild && typeof link.prodHref === 'string') {
+    return link.prodHref;
+  }
+  return link.href;
+};
+
+const moreMenuActive = NAV_MORE.some((link) => isNavActive(resolveNavHref(link)));
 
 const footerLinks = [
   ...NAV_MORE,
@@ -126,11 +138,12 @@ gtag('config', '${gaMeasurementId}');`}
           </div>
           <nav class="hidden w-full items-center justify-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-3 text-[0.65rem] uppercase tracking-[0.25em] text-white/70 backdrop-blur-2xl sm:gap-4 sm:text-[0.7rem] sm:tracking-[0.28em] lg:flex lg:flex-nowrap lg:text-sm lg:tracking-[0.3em]" aria-label="Primary">
             {NAV_PRIMARY.map((link) => {
-              const active = isNavActive(link.href);
+              const resolvedHref = resolveNavHref(link);
+              const active = isNavActive(resolvedHref);
               return (
                 <a
                   class={`whitespace-nowrap transition hover:text-rose-gold ${active ? 'text-rose-gold' : ''}`}
-                  href={withBase(link.href)}
+                  href={withBase(resolvedHref)}
                   aria-current={active ? 'page' : undefined}
                 >
                   {link.label}
@@ -154,17 +167,20 @@ gtag('config', '${gaMeasurementId}');`}
                 tabindex="-1"
               >
                 <ul class="flex flex-col gap-2 text-[0.65rem] uppercase tracking-[0.25em] text-white/70 lg:text-xs lg:tracking-[0.28em]">
-                  {NAV_MORE.map((link) => (
-                    <li>
-                      <a
-                        class="block rounded-full px-4 py-2 transition hover:bg-white/10 hover:text-rose-gold"
-                        href={withBase(link.href)}
-                        role="menuitem"
-                      >
-                        {link.label}
-                      </a>
-                    </li>
-                  ))}
+                  {NAV_MORE.map((link) => {
+                    const resolvedHref = resolveNavHref(link);
+                    return (
+                      <li>
+                        <a
+                          class="block rounded-full px-4 py-2 transition hover:bg-white/10 hover:text-rose-gold"
+                          href={withBase(resolvedHref)}
+                          role="menuitem"
+                        >
+                          {link.label}
+                        </a>
+                      </li>
+                    );
+                  })}
                 </ul>
               </div>
             </div>
@@ -192,11 +208,12 @@ gtag('config', '${gaMeasurementId}');`}
               </div>
               <nav class="flex flex-col gap-3 text-white/70" aria-label="Mobile primary">
                 {NAV_PRIMARY.map((link) => {
-                  const active = isNavActive(link.href);
+                  const resolvedHref = resolveNavHref(link);
+                  const active = isNavActive(resolvedHref);
                   return (
                     <a
                       class={`rounded-full border border-white/10 px-4 py-3 text-[0.65rem] tracking-[0.28em] transition hover:border-white/20 hover:text-rose-gold ${active ? 'border-rose-gold/50 text-rose-gold' : 'text-white/70'}`}
-                      href={withBase(link.href)}
+                      href={withBase(resolvedHref)}
                       data-nav-mobile-link
                       aria-current={active ? 'page' : undefined}
                     >
@@ -217,11 +234,12 @@ gtag('config', '${gaMeasurementId}');`}
                 </button>
                 <div class="hidden flex-col gap-2 text-[0.65rem] tracking-[0.28em] text-white/70" data-nav-mobile-more-panel>
                   {NAV_MORE.map((link) => {
-                    const active = isNavActive(link.href);
+                    const resolvedHref = resolveNavHref(link);
+                    const active = isNavActive(resolvedHref);
                     return (
                       <a
                         class={`rounded-full border border-white/10 px-4 py-3 transition hover:border-white/20 hover:text-rose-gold ${active ? 'border-rose-gold/50 text-rose-gold' : 'text-white/70'}`}
-                        href={withBase(link.href)}
+                        href={withBase(resolvedHref)}
                         data-nav-mobile-link
                       >
                         {link.label}
@@ -242,11 +260,14 @@ gtag('config', '${gaMeasurementId}');`}
       <footer class="border-t border-white/10 bg-black/40 py-10 backdrop-blur-2xl">
         <div class="mx-auto flex w-full max-w-6xl flex-col gap-3 px-6 text-xs uppercase tracking-[0.4em] text-white/45 sm:flex-row sm:items-center sm:justify-between">
           <div class="flex flex-wrap items-center gap-4 text-[0.7rem]">
-            {footerLinks.map((link) => (
-              <a class="transition hover:text-rose-gold" href={withBase(link.href)}>
-                {link.label}
-              </a>
-            ))}
+            {footerLinks.map((link) => {
+              const resolvedHref = resolveNavHref(link);
+              return (
+                <a class="transition hover:text-rose-gold" href={withBase(resolvedHref)}>
+                  {link.label}
+                </a>
+              );
+            })}
           </div>
           <div class="flex items-center gap-4 text-[0.7rem]">
             <a class="transition hover:text-rose-gold" href="mailto:concierge@naughtycamspot.com">

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -31,12 +31,12 @@ const formatDateStamp = () => {
 };
 
 const isPages = import.meta.env.IS_PAGES === 'true';
-const joinHrefPages = 'https://naughtycamspot.com/models';
+const joinHrefPages = PRIMARY_CTA.pagesHref;
 const joinHrefProd = `/go/model-join.php?src=blog_${post.slug}&camp=post&date=${formatDateStamp()}`;
-const joinRel = isPages ? 'noreferrer' : 'nofollow noreferrer';
+const joinRel = isPages ? undefined : 'nofollow noreferrer';
 const joinCtaLabel = isPages ? 'Join our concierge roster' : 'Join via tracked concierge';
 const startRightMessage = isPages
-  ? 'Pages previews point to the StartRight hub on GitHub Pages.'
+  ? 'Pages builds route through the StartRight concierge hub.'
   : 'Production routes directly to the on-site StartRight plan.';
 ---
 

--- a/src/pages/contests.astro
+++ b/src/pages/contests.astro
@@ -51,7 +51,7 @@ const joinHrefProd = `/go/model-join.php?src=contests_banner&camp=contests&date=
         <LinkCTA
           class="border border-rose-gold/60 bg-rose-gold text-midnight"
           label="Start enrollment"
-          href_pages="https://www.camsoda.com/models"
+          href_pages={PRIMARY_CTA.pagesHref}
           href_prod={joinHrefProd}
         />
         <LinkCTA

--- a/src/pages/join-models.astro
+++ b/src/pages/join-models.astro
@@ -2,6 +2,7 @@
 import BannerSlot from '../components/BannerSlot.astro';
 import LinkCTA from '../components/LinkCTA.astro';
 import MainLayout from '../layouts/MainLayout.astro';
+import { PRIMARY_CTA } from '../data/copy';
 import { getClaimUrl, isPagesBuild } from '../utils/links';
 
 const heroBullets = [
@@ -46,8 +47,6 @@ const faqItems = [
   }
 ];
 
-const CTA_PLACEHOLDER = 'https://naughtycamspot.com/models';
-
 const formatDateStamp = () => {
   const now = new Date();
   const year = String(now.getUTCFullYear());
@@ -56,10 +55,11 @@ const formatDateStamp = () => {
   return `${year}${month}${day}`;
 };
 
-const joinHrefPages = CTA_PLACEHOLDER;
+const joinHrefPages = PRIMARY_CTA.pagesHref;
 const joinHrefProdTemplate = '/go/model-join.php?src=join_models&camp=landing&date=YYYYMMDD';
 const joinHrefProd = joinHrefProdTemplate.replace('YYYYMMDD', formatDateStamp());
 const pagesBuild = isPagesBuild();
+const joinRel = pagesBuild ? undefined : 'noreferrer';
 const claimUrl = getClaimUrl();
 const claimLinkIsExternal = claimUrl.startsWith('http');
 const claimLinkTarget = claimLinkIsExternal ? '_blank' : undefined;
@@ -121,10 +121,10 @@ const onboardingSteps = [
           href_pages={joinHrefPages}
           href_prod={joinHrefProd}
           label="Start Concierge Intake"
-          rel="noreferrer"
+          rel={joinRel}
         />
         <p class="mt-3 text-xs uppercase tracking-[0.3em] text-white/40">
-          {pagesBuild ? 'Opens external concierge briefing' : 'Tracked via /go/model-join.php'}
+          {pagesBuild ? 'Routes through our StartRight concierge plan.' : 'Tracked via /go/model-join.php'}
         </p>
       </div>
     </div>

--- a/src/pages/join.astro
+++ b/src/pages/join.astro
@@ -1,5 +1,7 @@
 ---
+import LinkCTA from '../components/LinkCTA.astro';
 import MainLayout from '../layouts/MainLayout.astro';
+import { PRIMARY_CTA } from '../data/copy';
 import { buildTrackedLink, withBase } from '../utils/links';
 
 const HERO_CTA_PLACEHOLDER = 'https://linktr.ee/naughtycamspot';
@@ -28,6 +30,9 @@ const resolveHostname = (value: string | undefined) => {
 const siteHostname = resolveHostname(import.meta.env.SITE ?? '');
 const isPagesBuild = import.meta.env.IS_PAGES === 'true';
 const shouldTrackClicks = siteHostname === 'naughtycamspot.com' && !isPagesBuild;
+const joinHrefPages = PRIMARY_CTA.pagesHref;
+const ctaTarget = shouldTrackClicks ? '_blank' : undefined;
+const ctaRel = shouldTrackClicks ? 'noreferrer' : undefined;
 
 const howItWorks = [
   {
@@ -105,17 +110,18 @@ const faq = [
         NaughtyCamSpot is a referral + starter-kit hub. Click join, finish the partner program signup with our links, send proof,
         and we email the full 14-day launch kit—no promo promises, no management fees.
       </p>
-      <a
-        class="inline-flex w-fit items-center justify-center rounded-full border border-rose-gold/60 bg-rose-gold px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-midnight shadow-glow transition hover:-translate-y-1"
-        href={joinHref}
-        target="_blank"
-        rel="noreferrer"
+      <LinkCTA
+        class="inline-flex w-fit items-center justify-center border border-rose-gold/60 bg-rose-gold px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-midnight shadow-glow transition hover:-translate-y-1"
+        href_pages={joinHrefPages}
+        href_prod={joinHref}
+        target={ctaTarget}
+        rel={ctaRel}
         data-track={shouldTrackClicks ? 'click' : undefined}
         data-slot={shouldTrackClicks ? joinSlot : undefined}
         data-camp={shouldTrackClicks ? joinCamp : undefined}
       >
         Start camming • Free starter kit
-      </a>
+      </LinkCTA>
     </div>
   </section>
 
@@ -123,7 +129,9 @@ const faq = [
     <h2 class="section-heading">How it works</h2>
     <p class="text-sm text-white/70">
       Four simple steps keep the process transparent. The full breakdown lives in our
-      <a class="text-rose-gold underline-offset-4 hover:underline" href={withBase('/starter-kit')}>starter kit overview</a>
+      <a class="text-rose-gold underline-offset-4 hover:underline" href={withBase('/starter-kit')}>
+        starter kit overview
+      </a>
       so you always know what’s included.
     </p>
     <ol class="grid gap-4 text-sm text-white/70 sm:grid-cols-2">


### PR DESCRIPTION
## Summary
- route all generic CTA components through the shared StartRight target for GitHub Pages builds
- update banner, blog, join and navigation surfaces to consume PRIMARY_CTA defaults while keeping production rotators

## Files Modified
- src/data/banners.ts
- src/data/nav.ts
- src/layouts/MainLayout.astro
- src/pages/blog/[slug].astro
- src/pages/contests.astro
- src/pages/join-models.astro
- src/pages/join.astro

Program-specific join destinations continue to use their original tracking links.

## Testing
- npm run build:pages
- npm run test:pages-safety

------
https://chatgpt.com/codex/tasks/task_e_68f46454a390832688d943774bc4671d