### PR TITLE
Route Pages CTA traffic to StartRight

### DIFF
--- a/src/utils/links.js
+++ b/src/utils/links.js
@@ -49,14 +49,11 @@ export const withBase = (path = '') => {
   return `${BASE_URL}${cleanedPath}`;
 };
 
+const PAGES_FALLBACK_PATH = '/startright';
+
 export const buildTrackedLink = ({ path, slot, camp, placeholder }) => {
   if (IS_PAGES_BUILD) {
-    const sanitizedPlaceholder = sanitizePlaceholder(placeholder);
-    if (sanitizedPlaceholder && !sanitizedPlaceholder.startsWith('/go/')) {
-      return sanitizedPlaceholder;
-    }
-
-    return 'https://naughtycamspot.com';
+    return withBase(PAGES_FALLBACK_PATH);
   }
 
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;

--- a/tests/anna-links.test.mjs
+++ b/tests/anna-links.test.mjs
@@ -49,23 +49,15 @@ const collectPlatformOrder = (html) => {
   return matches.map(([, slug]) => slug);
 };
 
-test('Pages build uses external hrefs for Anna Prince', async () => {
+test('Pages build routes Anna Prince CTAs to StartRight', async () => {
   const { html } = await buildPage('pages');
 
-  const expected = {
-    manyvids: 'https://www.manyvids.com/live/cam/anna_prince',
-    beacons: 'https://beacons.ai/annaprince',
-    stripchat: 'https://stripchat.com/Anna_Prince',
-    chaturbate: 'https://chaturbate.com/b/anna_prince/',
-    camsoda: 'https://www.camsoda.com/annaprince',
-    pornhub: 'https://pornhub.com/model/sabrina_great',
-    onlyfans: 'https://onlyfans.com/sabrinagreat'
-  };
+  const expectedHref = '/naughtycamspot/startright';
 
-  for (const [platform, href] of Object.entries(expected)) {
+  for (const platform of ['manyvids', 'beacons', 'stripchat', 'chaturbate', 'camsoda', 'pornhub', 'onlyfans']) {
     const value = extractHref(html, platform);
     assert.ok(value, `expected ${platform} button to exist`);
-    assert.equal(value, href, `expected ${platform} href to match placeholder`);
+    assert.equal(value, expectedHref, `expected ${platform} href to point to StartRight`);
     assert.ok(!value.startsWith('/go/'), `${platform} href should not start with /go/ in Pages mode`);
   }
 

--- a/tests/banner-links.test.mjs
+++ b/tests/banner-links.test.mjs
@@ -31,15 +31,11 @@ const sample = {
     'https://leads.naughtycamspot.com/sponsor/home/home_top_leaderboard?slot=home_top_leaderboard&camp=home'
 };
 
-test('Pages builds fall back to safe external links', async () => {
+test('Pages builds route banners to StartRight', async () => {
   const { buildTrackedLink } = await loadLinksModule({ ASTRO_BASE_URL: '/naughtycamspot/' });
   const href = buildTrackedLink(sample);
   assert.ok(!href.startsWith('/go/'), 'Pages href must not point to /go/');
-  assert.equal(
-    href,
-    'https://leads.naughtycamspot.com/sponsor/home/home_top_leaderboard',
-    'Pages href should strip query params'
-  );
+  assert.equal(href, '/naughtycamspot/startright', 'Pages href should point to StartRight');
   assert.ok(!href.includes('?'), 'Pages href should not contain query params');
 });
 

--- a/tests/hero-cta.test.ts
+++ b/tests/hero-cta.test.ts
@@ -33,12 +33,12 @@ describe('Hero CTA routing', () => {
     expect(href).toBe('/go/model-join.php?src=home_hero&camp=home&date=20251017');
   });
 
-  it('emits safe external link for Pages builds', async () => {
+  it('routes Pages builds to StartRight', async () => {
     vi.stubEnv('BASE_URL', '/naughtycamspot/');
 
     const { buildTrackedLink } = await importLinksModule();
     const href = buildTrackedLink(heroParams);
 
-    expect(href).toBe(heroParams.placeholder);
+    expect(href).toBe('/naughtycamspot/startright');
   });
 });

--- a/tests/home-hero-cta.test.mjs
+++ b/tests/home-hero-cta.test.mjs
@@ -10,7 +10,7 @@ const importLinksWithBase = async (baseUrl) => {
   return module;
 };
 
-test('Pages build uses external placeholder link', async () => {
+test('Pages build routes CTA to StartRight', async () => {
   const { buildTrackedLink } = await importLinksWithBase('/docs/');
   const href = buildTrackedLink({
     path: '/go/model-join.php',
@@ -20,7 +20,7 @@ test('Pages build uses external placeholder link', async () => {
   });
 
   const anchorSnapshot = `<a href="${href}"></a>`;
-  assert.equal(anchorSnapshot, '<a href="https://linktr.ee/naughtycamspot"></a>');
+  assert.equal(anchorSnapshot, '<a href="/docs/startright"></a>');
 });
 
 test('Production build outputs tracked /go link', async () => {

--- a/tests/join-models-cta.test.mjs
+++ b/tests/join-models-cta.test.mjs
@@ -43,12 +43,13 @@ const extractCtaHref = (html) => {
   return match ? match[1] : undefined;
 };
 
-test('Pages build keeps Join Models CTA external', async () => {
+test('Pages build routes Join Models CTA to StartRight', async () => {
   const { html } = await buildJoinModelsPage('pages');
   const href = extractCtaHref(html);
 
   assert.ok(href, 'CTA href should be present');
   assert.ok(!href.startsWith('/go/'), 'Pages CTA must not start with /go/');
+  assert.equal(href, '/naughtycamspot/startright', 'Pages CTA should point to StartRight');
 });
 
 test('Production build uses tracked /go/ link for Join Models CTA', async () => {


### PR DESCRIPTION
## Summary
- route the Pages build fallback in `buildTrackedLink` to `/startright`
- update CTA routing tests to expect the StartRight path across hero, banner, model, and join flows

## Testing
- npm test
- npm run build:pages

------
https://chatgpt.com/codex/tasks/task_e_68f46a30e2c08326bd9eef558644253e