### PR TITLE
Add branch synchronization helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ chmod +x .githooks/pre-push
 
 The pre-push hook executes the Pages safety scan, JSON schema validation, and the hero snapshot test.
 
+### Branch synchronization
+
+Use the helper script to fast-forward every local branch to the latest remote state in one sweep:
+
+```bash
+./scripts/sync-all-branches.sh
+```
+
+The script fetches all remotes, skips dirty working trees, creates any missing local branches, and fast-forwards the rest. If a
+branch has diverged, the script will warn so you can handle the merge manually.
+
 ## SEO & indexing
 
 - Production builds (`astro.config.mjs`) enable `@astrojs/sitemap` with the public `site` domain locked to `https://naughtycamspot.com`. GitHub Pages builds continue to use `astro.config.pages.mjs` and inject a `<meta name="robots" content="noindex,nofollow">` tag so previews stay out of the index.

--- a/scripts/sync-all-branches.sh
+++ b/scripts/sync-all-branches.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "Error: This script must be run inside a Git repository." >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Error: Working tree has uncommitted changes. Please commit or stash them before syncing." >&2
+  exit 1
+fi
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+trap 'git checkout -q "$current_branch" >/dev/null 2>&1 || true' EXIT
+
+if [[ -z "$(git remote)" ]]; then
+  echo "No remotes configured. Nothing to sync."
+  exit 0
+fi
+
+echo "Fetching latest updates for all remotes..."
+git fetch --all --prune
+
+declare -a remote_refs
+mapfile -t remote_refs < <(git for-each-ref --format='%(refname:lstrip=2)' refs/remotes)
+
+if [[ ${#remote_refs[@]} -eq 0 ]]; then
+  echo "No remote branches found. Nothing to sync."
+  exit 0
+fi
+
+for ref in "${remote_refs[@]}"; do
+  remote_name="${ref%%/*}"
+  branch_name="${ref#*/}"
+
+  if [[ -z "$branch_name" || "$branch_name" == "HEAD" ]]; then
+    continue
+  fi
+
+  echo "Synchronizing $branch_name with $remote_name/$branch_name..."
+
+  if git show-ref --verify --quiet "refs/heads/$branch_name"; then
+    git checkout -q "$branch_name"
+    if git merge --ff-only "$remote_name/$branch_name"; then
+      echo "Fast-forwarded $branch_name to $remote_name/$branch_name."
+    else
+      echo "Warning: $branch_name has diverged from $remote_name/$branch_name; manual merge required." >&2
+    fi
+  else
+    git branch --track "$branch_name" "$remote_name/$branch_name"
+    echo "Created local branch $branch_name from $remote_name/$branch_name."
+  fi
+
+done
+
+git checkout -q "$current_branch"
+trap - EXIT
+echo "Restored original branch $current_branch."


### PR DESCRIPTION
## Summary
- add a `sync-all-branches.sh` helper that fetches remotes, creates tracking branches, and fast-forwards local branches
- document how to run the helper in the README for easy discovery

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68f47ac7da8c8326bed9fd337443ae7c