### PR TITLE
fix: replace broken hero strip image with inline camera icon + StartRight copy

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,4 @@
 ---
-import BannerSlot from '../components/BannerSlot.astro';
 import LinkCTA from '../components/LinkCTA.astro';
 import SEO from '../components/SEO.astro';
 import { HERO, PRIMARY_CTA } from '../data/copy';
@@ -125,7 +124,18 @@ const websiteJsonLd = {
   />
   <script type="application/ld+json" set:html={JSON.stringify(websiteJsonLd)} />
 
-  <BannerSlot id="home_top_leaderboard" showNote class="mb-10" />
+  <LinkCTA
+    class="mb-10 flex w-full items-center rounded-full border border-white/15 bg-white/5 px-5 py-4 text-white transition hover:bg-white/10"
+    pagesHref="/startright"
+    prodHref="/startright"
+  >
+    <svg class="mr-3 h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path
+        d="M7.5 6.75h2.062a1.5 1.5 0 0 0 1.06-.44l1.19-1.19A1.5 1.5 0 0 1 13.873 4h2.627A2.25 2.25 0 0 1 18.75 6.25V7.5H19.5A2.5 2.5 0 0 1 22 10v7.25A2.75 2.75 0 0 1 19.25 20H6.75A2.75 2.75 0 0 1 4 17.25V9.5A2.75 2.75 0 0 1 6.75 6.75h.75Zm4.25 9a4.25 4.25 0 1 0 0-8.5 4.25 4.25 0 0 0 0 8.5Zm0-1.5a2.75 2.75 0 1 1 0-5.5 2.75 2.75 0 0 1 0 5.5Z"
+      />
+    </svg>
+    <span class="text-sm tracking-[0.4em] sm:text-base">STARTRIGHT — GET YOUR FREE KIT</span>
+  </LinkCTA>
 
   <!-- SECTION: Hero -->
   <section id="gallery-hero" class="glass relative overflow-hidden rounded-[42px] px-10 py-16">


### PR DESCRIPTION
## Summary
- replace the home hero strip banner image with an inline camera icon and StartRight copy
- wire the strip through LinkCTA so it consistently routes visitors to /startright in pages and production builds

## Screenshots
- Before: _Not available in this environment (previous asset `/ads/leaderboard-970x90.svg` was missing and rendered broken)_
- After: _Not available in this environment (strip now renders inline SVG + StartRight copy)_

## Verification
- [ ] `npm run build` *(fails: `KIT` is not exported by `src/data/copy.ts`, existing issue when building main branch)*
- [x] Verified LinkCTA renders `href="/startright"` in the updated hero strip markup


------
https://chatgpt.com/codex/tasks/task_e_68f47f00cdd48326b2e873c99cfa72b2