### PR TITLE
fix: startright build error + hero strip icon + Skip CTA

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -124,18 +124,17 @@ const websiteJsonLd = {
   />
   <script type="application/ld+json" set:html={JSON.stringify(websiteJsonLd)} />
 
-  <LinkCTA
+  <a
+    href="/startright"
     class="mb-10 flex w-full items-center rounded-full border border-white/15 bg-white/5 px-5 py-4 text-white transition hover:bg-white/10"
-    pagesHref="/startright"
-    prodHref="/startright"
   >
     <svg class="mr-3 h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
       <path
         d="M7.5 6.75h2.062a1.5 1.5 0 0 0 1.06-.44l1.19-1.19A1.5 1.5 0 0 1 13.873 4h2.627A2.25 2.25 0 0 1 18.75 6.25V7.5H19.5A2.5 2.5 0 0 1 22 10v7.25A2.75 2.75 0 0 1 19.25 20H6.75A2.75 2.75 0 0 1 4 17.25V9.5A2.75 2.75 0 0 1 6.75 6.75h.75Zm4.25 9a4.25 4.25 0 1 0 0-8.5 4.25 4.25 0 0 0 0 8.5Zm0-1.5a2.75 2.75 0 1 1 0-5.5 2.75 2.75 0 0 1 0 5.5Z"
       />
     </svg>
-    <span class="text-sm tracking-[0.4em] sm:text-base">STARTRIGHT — GET YOUR FREE KIT</span>
-  </LinkCTA>
+    <span class="tracking-widest text-sm sm:text-base">STARTRIGHT — GET YOUR FREE KIT</span>
+  </a>
 
   <!-- SECTION: Hero -->
   <section id="gallery-hero" class="glass relative overflow-hidden rounded-[42px] px-10 py-16">

--- a/src/pages/startright.astro
+++ b/src/pages/startright.astro
@@ -3,8 +3,11 @@ import LinkCTA from '../components/LinkCTA.astro';
 import Notices from '../components/Notices.astro';
 import SEO from '../components/SEO.astro';
 import MainLayout from '../layouts/MainLayout.astro';
-import { PRIMARY_CTA, STARTRIGHT_SKIP } from '../data/copy';
+import { HERO, PRIMARY_CTA, STARTRIGHT_SKIP } from '../data/copy';
 import programs from '../data/programs.json';
+
+const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+const qs = `?src=${STARTRIGHT_SKIP.tracking.src}&camp=${STARTRIGHT_SKIP.tracking.camp}&date=${today}`;
 
 interface Program {
   key: string;
@@ -14,6 +17,8 @@ interface Program {
   best_for: string[];
 }
 
+const canonicalPath = '/startright';
+
 const formatDateStamp = () => {
   const now = new Date();
   const year = String(now.getUTCFullYear());
@@ -22,14 +27,26 @@ const formatDateStamp = () => {
   return `${year}${month}${day}`;
 };
 
-const canonicalPath = '/startright';
+const goBase = import.meta.env.IS_PAGES === 'true' ? '' : '/go';
+const modelJoinPath = `${goBase}/model-join.php`.replace(/\/{2,}/g, '/');
+
+const buildJoinHref = (key: string, date: string) => {
+  const params = new URLSearchParams({
+    src: `startright_${key}`,
+    camp: 'startright',
+    date,
+    slot: `startright_${key}`
+  });
+  return `${modelJoinPath}?${params.toString()}`;
+};
+
 const dateStamp = formatDateStamp();
-const skipQuery = `?src=${STARTRIGHT_SKIP.tracking.src}&camp=${STARTRIGHT_SKIP.tracking.camp}&date=${dateStamp}`;
-const skipHrefPages = `${STARTRIGHT_SKIP.pagesHrefBase}${skipQuery}`;
+const skipHrefPages = `${STARTRIGHT_SKIP.pagesHrefBase}${qs}`;
 const skipHrefProd = skipHrefPages;
+
 const basePrograms = (programs as Program[]).map((program) => {
   const joinHrefPages = program.join_base;
-  const joinHrefProdTemplate = `${goPrefix}model-join.php?src=startright_${program.key}&camp=startright&date=YYYYMMDD`;
+  const joinHrefProdTemplate = `${modelJoinPath}?src=startright_${program.key}&camp=startright&date=YYYYMMDD`;
   const joinHrefProd = buildJoinHref(program.key, dateStamp);
 
   return {
@@ -160,6 +177,17 @@ const clientPrograms = JSON.stringify(
         Tune the inputs to match your situation. We&apos;ll translate those signals into a ranked list of partner programs, share
         why they fit, and route you to the guarded links you need to unlock the StartRight launch kit.
       </p>
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <LinkCTA
+          class="border border-rose-gold/60 bg-rose-gold text-midnight text-sm tracking-[0.2em] shadow-glow"
+          pagesHref={PRIMARY_CTA.pagesHref}
+          prodHref={PRIMARY_CTA.prodHref}
+          label={PRIMARY_CTA.label}
+        />
+        <a href={`/join-models${qs}`} class="btn btn-secondary w-full sm:w-auto">
+          Skip — pick my platforms
+        </a>
+      </div>
     </div>
     <form id="recommend-form" class="grid gap-6 rounded-[32px] border border-white/10 bg-white/5 p-6 backdrop-blur-2xl">
       <div class="grid gap-4 sm:grid-cols-2">
@@ -252,26 +280,26 @@ const clientPrograms = JSON.stringify(
                   ) : (
                     <LinkCTA
                       class="border border-rose-gold/60 bg-rose-gold text-midnight"
-                      href_pages={result.joinHrefPages}
-                      href_prod={result.joinHrefProd}
+                      pagesHref={result.joinHrefPages}
+                      prodHref={result.joinHrefProd}
                       label="Join with our links"
                     />
                   )}
                 </div>
                 <div class="flex flex-col gap-2 sm:items-start">
                   <LinkCTA
-                    class="border border-rose-gold/60 bg-rose-gold text-midnight"
-                    pagesHref={result.joinHrefPages}
-                    prodHref={result.joinHrefProd}
-                    label="Join with our links"
+                    class="border border-white/20 bg-transparent text-white hover:bg-white/10"
+                    pagesHref={PRIMARY_CTA.pagesHref}
+                    prodHref={PRIMARY_CTA.prodHref}
+                    label={PRIMARY_CTA.label}
                   />
-                )}
-                <LinkCTA
-                  class="border border-white/20 bg-transparent text-white hover:bg-white/10"
-                  pagesHref={PRIMARY_CTA.pagesHref}
-                  prodHref={PRIMARY_CTA.prodHref}
-                  label={PRIMARY_CTA.label}
-                />
+                  <LinkCTA
+                    class="border border-white/15 bg-transparent text-white/70 hover:border-white/30 hover:bg-white/10 hover:text-white"
+                    pagesHref={skipHrefPages}
+                    prodHref={skipHrefProd}
+                    label={STARTRIGHT_SKIP.label}
+                  />
+                </div>
               </div>
             </header>
             <ul class="mt-4 space-y-2 text-sm text-white/70">
@@ -307,7 +335,7 @@ const clientPrograms = JSON.stringify(
         const now = new Date();
         return `${now.getUTCFullYear()}${String(now.getUTCMonth() + 1).padStart(2, '0')}${String(now.getUTCDate()).padStart(2, '0')}`;
       };
-      const goPrefix = `/${String.fromCharCode(103, 111)}/`;
+      const goBase = isPagesBuild ? '' : `/${String.fromCharCode(103, 111)}`;
       const searchParams = new URLSearchParams(window.location.search);
       const inboundSrc = searchParams.get('src') || '';
       const inboundCamp = searchParams.get('camp') || '';
@@ -334,7 +362,8 @@ const clientPrograms = JSON.stringify(
         if (tracking.camp) params.set('camp', tracking.camp);
         if (tracking.date) params.set('date', tracking.date);
         if (tracking.slot) params.set('slot', tracking.slot);
-        return `${goPrefix}model-join.php?${params.toString()}`;
+        const joinPath = goBase ? `${goBase}/model-join.php` : '/model-join.php';
+        return `${joinPath}?${params.toString()}`;
       };
       const applyTrackingToPath = (href, defaults) => {
         if (!href || /^https?:\/\//i.test(href)) {

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -70,6 +70,14 @@
   .video-placeholder {
     @apply flex h-40 items-center justify-center rounded-2xl border border-white/10 bg-black/30 text-sm uppercase tracking-[0.3em] text-white/50 backdrop-blur-xl;
   }
+
+  .btn {
+    @apply inline-flex items-center justify-center rounded-full px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] transition hover:-translate-y-1;
+  }
+
+  .btn-secondary {
+    @apply border border-white/15 bg-white/5 text-white/70 backdrop-blur-xl hover:border-white/30 hover:bg-white/10 hover:text-white;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- repair StartRight frontmatter helpers so build passes and join links avoid `/go/` on Pages builds while exposing the Skip query params
- add the primary and Skip CTAs (with button styling) to the StartRight hero and adjust recommendation cards to surface the Skip action
- replace the homepage hero strip with the inline SVG link to /startright

## Testing
- npm run build
- npm run build:pages

------
https://chatgpt.com/codex/tasks/task_e_68f48657fa64832697464c5e92f2a59f