### PR TITLE
Add Case Studies link to secondary navigation

### DIFF
--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -16,6 +16,7 @@ export const NAV_PRIMARY: NavLink[] = [
 export const NAV_MORE: NavLink[] = [
   { href: '/contests', label: 'Contests' },
   { href: '/models', label: 'Models' },
+  { href: '/case-studies', label: 'Case Studies' },
   { href: '/starter-kit', label: 'Starter Kit' },
   { href: '/startright', label: 'Join Models', prodHref: '/join-models' },
   { href: '/claim', label: 'Claim' }


### PR DESCRIPTION
## Summary
- add the Case Studies stub to the secondary navigation set so it appears in the header and footer menus

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f48beedec08326ae557868e7cc918f