### PR TITLE
Update program status gating for compare and StartRight

### DIFF
--- a/WORK_QUEUE.md
+++ b/WORK_QUEUE.md
@@ -1,9 +1,9 @@
 # NCS Work Queue (commit directly to main, no PR)
 
 ## [#72] Programs registry + UI wiring
-- [ ] Add src/data/programs.json (camsoda approved, chaturbate approved, bonga pending, jasmin pending, stripchat blocked, myclub low_priority, pornhub research)
-- [ ] Compare + StartRight read status; pending = disabled join, approved = join_base (Pages)
-- [ ] Build passes; Pages HTML has no /go/*
+- [x] Add src/data/programs.json (camsoda approved, chaturbate approved, bonga pending, jasmin pending, stripchat blocked, myclub low_priority, pornhub research)
+- [x] Compare + StartRight read status; pending = disabled join, approved = join_base (Pages)
+- [x] Build passes; Pages HTML has no /go/*
 
 ## [#] Models data source + pages
 - [ ] Add src/data/models.json (Anna links filled; Mia approved:false)

--- a/schemas/programs.schema.json
+++ b/schemas/programs.schema.json
@@ -32,7 +32,10 @@
         "type": "array",
         "items": { "type": "string", "minLength": 1 }
       },
-      "status": { "type": "string", "enum": ["pending", "approved"] }
+      "status": {
+        "type": "string",
+        "enum": ["approved", "pending", "blocked", "low_priority", "research"]
+      }
     }
   }
 }

--- a/src/data/programStatus.ts
+++ b/src/data/programStatus.ts
@@ -1,0 +1,87 @@
+export type ProgramStatus =
+  | 'approved'
+  | 'pending'
+  | 'blocked'
+  | 'low_priority'
+  | 'research';
+
+export type ProgramStatusMeta = {
+  label: string;
+  badgeClass: string;
+  textClass: string;
+  disclosure: string;
+  joinDisabledLabel: string;
+  allowsJoin: boolean;
+};
+
+const FALLBACK_LABEL = 'Pending review';
+
+const FALLBACK_META: ProgramStatusMeta = {
+  label: FALLBACK_LABEL,
+  badgeClass: 'bg-amber-300/10 text-amber-200',
+  textClass: 'text-amber-200',
+  disclosure: 'Awaiting affiliate paperwork.',
+  joinDisabledLabel: 'Join path pending',
+  allowsJoin: false
+};
+
+export const PROGRAM_STATUS_META: Record<ProgramStatus, ProgramStatusMeta> = {
+  approved: {
+    label: 'Approved',
+    badgeClass: 'bg-emerald-400/10 text-emerald-300',
+    textClass: 'text-emerald-300',
+    disclosure: 'Live tracking.',
+    joinDisabledLabel: 'Join path ready',
+    allowsJoin: true
+  },
+  pending: {
+    label: 'Pending',
+    badgeClass: 'bg-amber-300/10 text-amber-200',
+    textClass: 'text-amber-200',
+    disclosure: 'Awaiting final affiliate paperwork.',
+    joinDisabledLabel: 'Join path pending',
+    allowsJoin: false
+  },
+  blocked: {
+    label: 'Blocked',
+    badgeClass: 'bg-rose-400/10 text-rose-200',
+    textClass: 'text-rose-200',
+    disclosure: 'Blocked due to compliance hold.',
+    joinDisabledLabel: 'Program blocked',
+    allowsJoin: false
+  },
+  low_priority: {
+    label: 'Low priority',
+    badgeClass: 'bg-sky-400/10 text-sky-200',
+    textClass: 'text-sky-200',
+    disclosure: 'Access reserved for established creators we already manage.',
+    joinDisabledLabel: 'Low-priority access only',
+    allowsJoin: false
+  },
+  research: {
+    label: 'Research',
+    badgeClass: 'bg-purple-400/10 text-purple-200',
+    textClass: 'text-purple-200',
+    disclosure: 'In research — no onboarding yet.',
+    joinDisabledLabel: 'Research in progress',
+    allowsJoin: false
+  }
+};
+
+const TITLE_CASE = /(^|_)([a-z])/g;
+
+export const resolveProgramStatusMeta = (status: string): ProgramStatusMeta => {
+  if ((status as ProgramStatus) in PROGRAM_STATUS_META) {
+    return PROGRAM_STATUS_META[status as ProgramStatus];
+  }
+
+  const normalizedLabel = status
+    .toLowerCase()
+    .replace(TITLE_CASE, (_, prefix: string, letter: string) => `${prefix === '_' ? ' ' : prefix}${letter.toUpperCase()}`)
+    .trim();
+
+  return {
+    ...FALLBACK_META,
+    label: normalizedLabel || FALLBACK_META.label
+  };
+};

--- a/src/data/programs.json
+++ b/src/data/programs.json
@@ -32,7 +32,55 @@
     "kyc": "medium",
     "traffic": "high EU/EE",
     "geo": "T1–T4 bounty tiers",
-    "best_for": ["GEO-tuned payouts"],
-    "status": "approved"
+    "best_for": ["GEO-tuned payouts", "regional promos"],
+    "status": "pending"
+  },
+  {
+    "key": "jasmin",
+    "name": "Jasmin",
+    "join_base": "https://modelcenter.jasmin.com/en/signup",
+    "subid_params": [],
+    "payout": "twice monthly",
+    "kyc": "strict",
+    "traffic": "high EU premium",
+    "geo": "EU focus, limited US",
+    "best_for": ["studio-managed creators", "premium cam niches"],
+    "status": "pending"
+  },
+  {
+    "key": "stripchat",
+    "name": "Stripchat",
+    "join_base": "https://stripchat.com/studio/start-streaming",
+    "subid_params": [],
+    "payout": "weekly",
+    "kyc": "medium",
+    "traffic": "global live traffic",
+    "geo": "Global with strong EU/LatAm",
+    "best_for": ["interactive cam formats", "token whales"],
+    "status": "blocked"
+  },
+  {
+    "key": "myclub",
+    "name": "My.Club",
+    "join_base": "https://track.naughtycamspot.com/myclub/models",
+    "subid_params": ["subid"],
+    "payout": "monthly",
+    "kyc": "medium",
+    "traffic": "boutique fanbase",
+    "geo": "T1 studio referrals",
+    "best_for": ["high-touch fan clubs", "established creators"],
+    "status": "low_priority"
+  },
+  {
+    "key": "pornhub",
+    "name": "Pornhub",
+    "join_base": "https://track.naughtycamspot.com/pornhub/models",
+    "subid_params": ["subid"],
+    "payout": "monthly",
+    "kyc": "strict",
+    "traffic": "massive global",
+    "geo": "Global, content-tiered",
+    "best_for": ["multi-platform expansion", "studio catalog monetization"],
+    "status": "research"
   }
 ]

--- a/src/pages/compare.astro
+++ b/src/pages/compare.astro
@@ -4,6 +4,7 @@ import Notices from '../components/Notices.astro';
 import MainLayout from '../layouts/MainLayout.astro';
 import { PRIMARY_CTA } from '../data/copy';
 import programs from '../data/programs.json';
+import { resolveProgramStatusMeta, type ProgramStatus } from '../data/programStatus';
 
 interface Program {
   key: string;
@@ -15,8 +16,19 @@ interface Program {
   traffic: string;
   geo: string;
   best_for: string[];
-  status: 'approved' | 'pending';
+  status: ProgramStatus;
 }
+
+type ProgramCard = Program & {
+  joinHrefPages: string;
+  joinHrefProd: string;
+  joinDisabled: boolean;
+  subidLine: string;
+  statusLabel: string;
+  statusBadgeClass: string;
+  statusDisclosure: string;
+  joinDisabledLabel: string;
+};
 
 const formatDateStamp = () => {
   const now = new Date();
@@ -27,18 +39,23 @@ const formatDateStamp = () => {
 };
 
 const dateStamp = formatDateStamp();
-const programCards = (programs as Program[]).map((program) => {
+const programCards: ProgramCard[] = (programs as Program[]).map((program) => {
   const joinHrefProd = `/go/model-join.php?src=compare_${program.key}&camp=compare&date=${dateStamp}`;
   const joinHrefPages = program.join_base;
+  const statusMeta = resolveProgramStatusMeta(program.status);
   const joinDisabled =
-    program.status !== 'approved' || !/^https?:\/\//i.test(joinHrefPages ?? '');
+    !statusMeta.allowsJoin || !/^https?:\/\//i.test(joinHrefPages ?? '');
 
   return {
     ...program,
     joinHrefPages,
     joinHrefProd,
     joinDisabled,
-    subidLine: program.subid_params.length > 0 ? `SubID params: ${program.subid_params.join(', ')}` : 'No subID params yet.'
+    subidLine: program.subid_params.length > 0 ? `SubID params: ${program.subid_params.join(', ')}` : 'No subID params yet.',
+    statusLabel: statusMeta.label,
+    statusBadgeClass: statusMeta.badgeClass,
+    statusDisclosure: statusMeta.disclosure,
+    joinDisabledLabel: statusMeta.joinDisabledLabel
   };
 });
 ---
@@ -60,13 +77,9 @@ const programCards = (programs as Program[]).map((program) => {
             <div class="flex items-center justify-between gap-3">
               <h2 class="font-display text-2xl text-white">{program.name}</h2>
               <span
-                class={`rounded-full px-3 py-1 text-[0.55rem] uppercase tracking-[0.3em] ${
-                  program.status === 'approved'
-                    ? 'bg-emerald-400/10 text-emerald-300'
-                    : 'bg-amber-300/10 text-amber-200'
-                }`}
+                class={`rounded-full px-3 py-1 text-[0.55rem] uppercase tracking-[0.3em] ${program.statusBadgeClass}`}
               >
-                {program.status === 'approved' ? 'Approved' : 'Pending'}
+                {program.statusLabel}
               </span>
             </div>
             <div class="flex flex-wrap gap-2 text-[0.65rem] uppercase tracking-[0.3em] text-white/60">
@@ -93,7 +106,7 @@ const programCards = (programs as Program[]).map((program) => {
             <div class="flex flex-col gap-3 sm:flex-row">
               {program.joinDisabled ? (
                 <span class="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-6 py-3 text-xs uppercase tracking-[0.3em] text-white/40">
-                  Join path pending
+                  {program.joinDisabledLabel}
                 </span>
               ) : (
                 <LinkCTA
@@ -112,7 +125,7 @@ const programCards = (programs as Program[]).map((program) => {
             </div>
             <div class="space-y-1">
               <p>{program.subidLine}</p>
-              <p>Status disclosure: {program.status === 'approved' ? 'Live tracking.' : 'Awaiting final affiliate paperwork.'}</p>
+              <p>Status disclosure: {program.statusDisclosure}</p>
             </div>
           </footer>
         </article>

--- a/src/pages/earnings.astro
+++ b/src/pages/earnings.astro
@@ -5,12 +5,13 @@ import MainLayout from '../layouts/MainLayout.astro';
 import { PRIMARY_CTA } from '../data/copy';
 import earnings from '../data/earnings.json';
 import programs from '../data/programs.json';
+import { resolveProgramStatusMeta, type ProgramStatus } from '../data/programStatus';
 
 interface Program {
   key: string;
   name: string;
   join_base: string;
-  status: 'approved' | 'pending';
+  status: ProgramStatus;
 }
 
 const formatDateStamp = () => {
@@ -37,7 +38,8 @@ const cards = bandEntries.map(([key, bands]) => {
   const joinHrefPages = program?.join_base ?? '';
   const joinHrefProdTemplate = `/go/model-join.php?src=earnings_${key}&camp=earnings&date=YYYYMMDD`;
   const joinHrefProd = joinHrefProdTemplate.replace('YYYYMMDD', dateStamp);
-  const joinDisabled = !program || program.status !== 'approved' || !/^https?:\/\//i.test(joinHrefPages);
+  const statusMeta = resolveProgramStatusMeta(program?.status ?? 'pending');
+  const joinDisabled = !statusMeta.allowsJoin || !/^https?:\/\//i.test(joinHrefPages);
 
   return {
     key,
@@ -45,7 +47,8 @@ const cards = bandEntries.map(([key, bands]) => {
     bands,
     joinHrefPages,
     joinHrefProd,
-    joinDisabled
+    joinDisabled,
+    joinDisabledLabel: statusMeta.joinDisabledLabel
   };
 });
 ---
@@ -81,7 +84,7 @@ const cards = bandEntries.map(([key, bands]) => {
             <div class="flex flex-col gap-3 sm:flex-row">
               {card.joinDisabled ? (
                 <span class="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-6 py-3 text-xs uppercase tracking-[0.3em] text-white/40">
-                  Join path pending
+                  {card.joinDisabledLabel}
                 </span>
               ) : (
                 <LinkCTA

--- a/src/pages/startright.astro
+++ b/src/pages/startright.astro
@@ -5,6 +5,7 @@ import SEO from '../components/SEO.astro';
 import MainLayout from '../layouts/MainLayout.astro';
 import { HERO, PRIMARY_CTA, STARTRIGHT_SKIP } from '../data/copy';
 import programs from '../data/programs.json';
+import { resolveProgramStatusMeta, type ProgramStatus } from '../data/programStatus';
 
 const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
 const qs = `?src=${STARTRIGHT_SKIP.tracking.src}&camp=${STARTRIGHT_SKIP.tracking.camp}&date=${today}`;
@@ -13,7 +14,7 @@ interface Program {
   key: string;
   name: string;
   join_base: string;
-  status: 'approved' | 'pending';
+  status: ProgramStatus;
   best_for: string[];
 }
 
@@ -48,13 +49,19 @@ const basePrograms = (programs as Program[]).map((program) => {
   const joinHrefPages = program.join_base;
   const joinHrefProdTemplate = `${modelJoinPath}?src=startright_${program.key}&camp=startright&date=YYYYMMDD`;
   const joinHrefProd = buildJoinHref(program.key, dateStamp);
+  const statusMeta = resolveProgramStatusMeta(program.status);
 
   return {
     ...program,
     joinHrefPages,
     joinHrefProd,
     joinHrefProdTemplate,
-    joinDisabled: program.status !== 'approved' || !/^https?:\/\//i.test(joinHrefPages ?? '')
+    joinDisabled: !statusMeta.allowsJoin || !/^https?:\/\//i.test(joinHrefPages ?? ''),
+    statusLabel: statusMeta.label,
+    statusTextClass: statusMeta.textClass,
+    statusDisclosure: statusMeta.disclosure,
+    joinDisabledLabel: statusMeta.joinDisabledLabel,
+    statusAllowsJoin: statusMeta.allowsJoin
   };
 });
 
@@ -152,8 +159,13 @@ const clientPrograms = JSON.stringify(
     name: program.name,
     joinHrefPages: program.joinHrefPages,
     joinDisabled: program.joinDisabled,
+    joinDisabledLabel: program.joinDisabledLabel,
     best_for: program.best_for,
-    status: program.status
+    status: program.status,
+    statusLabel: program.statusLabel,
+    statusTextClass: program.statusTextClass,
+    statusDisclosure: program.statusDisclosure,
+    statusAllowsJoin: program.statusAllowsJoin
   }))
 );
 ---
@@ -267,15 +279,17 @@ const clientPrograms = JSON.stringify(
             <header class="flex flex-wrap items-center justify-between gap-3">
               <div>
                 <h3 class="font-display text-2xl text-white">{result.name}</h3>
-                {result.status !== 'approved' && (
-                  <p class="text-xs uppercase tracking-[0.35em] text-amber-200">Pending</p>
+                {!result.statusAllowsJoin && (
+                  <p class={`text-xs uppercase tracking-[0.35em] ${result.statusTextClass}`}>
+                    {result.statusLabel}
+                  </p>
                 )}
               </div>
               <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4">
                 <div class="flex flex-col gap-2 sm:flex-row sm:items-start">
                   {result.joinDisabled ? (
                     <span class="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-6 py-3 text-xs uppercase tracking-[0.3em] text-white/40">
-                      Join path pending
+                      {result.joinDisabledLabel}
                     </span>
                   ) : (
                     <LinkCTA
@@ -323,7 +337,16 @@ const clientPrograms = JSON.stringify(
     const resultsContainer = document.querySelector('#recommend-results');
     const list = document.querySelector('#recommendation-list');
     if (form && resultsContainer && list) {
-      const programs = JSON.parse(resultsContainer.dataset.programs || '[]');
+    const rawPrograms = JSON.parse(resultsContainer.dataset.programs || '[]');
+    const programs = rawPrograms.map((program) => ({
+      ...program,
+      joinDisabled: program.joinDisabled === true,
+      joinDisabledLabel: program.joinDisabledLabel || 'Join path pending',
+      statusLabel: program.statusLabel || 'Pending',
+      statusTextClass: program.statusTextClass || 'text-amber-200',
+      statusAllowsJoin: program.statusAllowsJoin === true,
+      statusDisclosure: program.statusDisclosure || 'Awaiting final affiliate paperwork.'
+    }));
       const isPagesBuild = resultsContainer.dataset.isPages === 'true';
       const primaryLabel = resultsContainer.dataset.primaryLabel || 'Get my plan';
       const primaryPages = resultsContainer.dataset.primaryPages || '/startright';
@@ -472,13 +495,16 @@ const clientPrograms = JSON.stringify(
             const joinHrefProd = result.joinHrefProd;
             const resolvedJoinHref = isPagesBuild ? joinHrefPages : joinHrefProd;
             const joinDisabled =
-              result.joinDisabled || (isPagesBuild ? !/^https?:\/\//i.test(joinHrefPages || '') : !resolvedJoinHref);
+              result.joinDisabled ||
+              !result.statusAllowsJoin ||
+              (isPagesBuild ? !/^https?:\/\//i.test(joinHrefPages || '') : !resolvedJoinHref);
             const joinLabel = 'Join with our links';
             const joinIsExternal = /^https?:\/\//i.test(resolvedJoinHref);
             const joinTarget = joinIsExternal ? '_blank' : '_self';
             const joinRel = joinIsExternal ? 'nofollow noopener' : '';
+            const joinDisabledLabel = result.joinDisabledLabel || 'Join path pending';
             const joinButton = joinDisabled
-              ? `<span class="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-6 py-3 text-xs uppercase tracking-[0.3em] text-white/40" aria-disabled="true">${joinLabel}</span>`
+              ? `<span class="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-6 py-3 text-xs uppercase tracking-[0.3em] text-white/40" aria-disabled="true">${joinDisabledLabel}</span>`
               : `<a class="inline-flex items-center justify-center rounded-full border border-rose-gold/60 bg-rose-gold px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-midnight shadow-glow transition hover:-translate-y-1" href="${resolvedJoinHref}" target="${joinTarget}"${joinRel ? ` rel="${joinRel}"` : ''}>${joinLabel}${joinIsExternal ? '<span class="ml-2" aria-hidden="true">↗</span>' : ''}</a>`;
             const primaryHref = isPagesBuild ? primaryPages : primaryProd;
             const primaryIsExternal = /^https?:\/\//i.test(primaryHref);
@@ -490,10 +516,10 @@ const clientPrograms = JSON.stringify(
             const skipTarget = skipIsExternal ? '_blank' : '_self';
             const skipRel = skipIsExternal ? 'nofollow noopener' : '';
             const skipButton = `<a class="inline-flex items-center justify-center rounded-full border border-white/15 bg-transparent px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white/70 transition hover:-translate-y-1 hover:border-white/30 hover:bg-white/10 hover:text-white" href="${skipHref}" target="${skipTarget}"${skipRel ? ` rel="${skipRel}"` : ''}>${skipLabel}${skipIsExternal ? '<span class="ml-2" aria-hidden="true">↗</span>' : ''}</a>`;
-            const pendingLabel = result.status !== 'approved'
-              ? '<p class="text-xs uppercase tracking-[0.35em] text-amber-200">Pending</p>'
+            const statusLabel = !result.statusAllowsJoin
+              ? `<p class="text-xs uppercase tracking-[0.35em] ${result.statusTextClass || 'text-amber-200'}">${result.statusLabel || 'Pending'}</p>`
               : '';
-            return `<article class="rounded-3xl border border-white/10 bg-black/30 p-5"><header class="flex flex-wrap items-center justify-between gap-3"><div><h3 class="font-display text-2xl text-white">${result.name}</h3>${pendingLabel}</div><div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4"><div class="flex flex-col gap-2 sm:flex-row sm:items-start">${joinButton}</div><div class="flex flex-col gap-2 sm:items-start">${primaryButton}${skipButton}</div></div></header><ul class="mt-4 space-y-2 text-sm text-white/70">${reasons}</ul></article>`;
+            return `<article class="rounded-3xl border border-white/10 bg-black/30 p-5"><header class="flex flex-wrap items-center justify-between gap-3"><div><h3 class="font-display text-2xl text-white">${result.name}</h3>${statusLabel}</div><div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4"><div class="flex flex-col gap-2 sm:flex-row sm:items-start">${joinButton}</div><div class="flex flex-col gap-2 sm:items-start">${primaryButton}${skipButton}</div></div></header><ul class="mt-4 space-y-2 text-sm text-white/70">${reasons}</ul></article>`;
           })
           .join('');
       };


### PR DESCRIPTION
## Summary
- expand `programs.json` with the current program roster and status metadata
- add shared status helpers and update compare, earnings, and StartRight flows to respect gating

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f550da71f88326ae491e25c86bce4b