### PR TITLE
Align program gating with updated onboarding data

### DIFF
--- a/public/go/affiliates.php
+++ b/public/go/affiliates.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 const GO_SUBID_PARAM = 'subid';
 const GO_MODEL_PROGRAM_CONFIG = [
     'bonga' => [
-        'active' => true,
+        'active' => false,
         'tiers' => ['T1', 'T2', 'T3', 'T4'],
     ],
     'camsoda' => [
@@ -204,14 +204,8 @@ function go_build_camsoda_model_signup(string $subid): string
 {
     $base = 'https://www.camsoda.com/models?id=naughtycamboss';
     $tracking = $subid !== '' ? $subid : 'default';
-    $query = http_build_query([
-        's1' => $tracking,
-        'track' => $tracking,
-    ], '', '&', PHP_QUERY_RFC3986);
 
-    $separator = strpos($base, '?') !== false ? '&' : '?';
-
-    return $base . $separator . $query;
+    return go_append_subid($base, $tracking);
 }
 
 function go_build_chaturbate_model_signup(string $subid): string

--- a/schemas/programs.schema.json
+++ b/schemas/programs.schema.json
@@ -19,7 +19,11 @@
     "properties": {
       "key": { "type": "string", "minLength": 1 },
       "name": { "type": "string", "minLength": 1 },
-      "join_base": { "type": "string", "minLength": 1 },
+      "join_base": {
+        "type": "string",
+        "pattern": "^(?:https?:\\/\\/[^\\s]+)?$",
+        "description": "Base join URL; leave blank while onboarding is gated."
+      },
       "subid_params": {
         "type": "array",
         "items": { "type": "string", "minLength": 1 }

--- a/src/data/programs.json
+++ b/src/data/programs.json
@@ -3,7 +3,7 @@
     "key": "camsoda",
     "name": "CamSoda",
     "join_base": "https://www.camsoda.com/models?id=naughtycamboss",
-    "subid_params": ["s1", "track"],
+    "subid_params": ["subid"],
     "payout": "weekly",
     "kyc": "low friction",
     "traffic": "good in NA",
@@ -38,7 +38,7 @@
   {
     "key": "jasmin",
     "name": "Jasmin",
-    "join_base": "https://modelcenter.jasmin.com/en/signup",
+    "join_base": "",
     "subid_params": [],
     "payout": "twice monthly",
     "kyc": "strict",
@@ -50,7 +50,7 @@
   {
     "key": "stripchat",
     "name": "Stripchat",
-    "join_base": "https://stripchat.com/studio/start-streaming",
+    "join_base": "",
     "subid_params": [],
     "payout": "weekly",
     "kyc": "medium",
@@ -62,8 +62,8 @@
   {
     "key": "myclub",
     "name": "My.Club",
-    "join_base": "https://track.naughtycamspot.com/myclub/models",
-    "subid_params": ["subid"],
+    "join_base": "",
+    "subid_params": [],
     "payout": "monthly",
     "kyc": "medium",
     "traffic": "boutique fanbase",
@@ -74,8 +74,8 @@
   {
     "key": "pornhub",
     "name": "Pornhub",
-    "join_base": "https://track.naughtycamspot.com/pornhub/models",
-    "subid_params": ["subid"],
+    "join_base": "",
+    "subid_params": [],
     "payout": "monthly",
     "kyc": "strict",
     "traffic": "massive global",


### PR DESCRIPTION
## Summary
- update program metadata to reflect current onboarding statuses and gating rules
- allow join_base fields to be blank in the schema while programs are gated
- adjust CamSoda redirect tracking and disable the Bonga model program while pending

## Testing
- npm run check:schemas
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f561c1920c8326b921179eb5898fa2