### PR TITLE
Expand models library view and coverage

### DIFF
--- a/src/content/models/anna-prince.json
+++ b/src/content/models/anna-prince.json
@@ -9,6 +9,9 @@
     "https://images.unsplash.com/photo-1503341455253-b2e723bb3dbb?auto=format&fit=crop&w=900&q=80",
     "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=900&q=80"
   ],
+  "consent": true,
+  "quote": "When concierge runs the trenches, I stay in ritual mode and the conversions never slip.",
+  "range_band": "top10",
   "featured": true,
   "featuredOrder": 1,
   "platforms": [

--- a/src/data/banners.ts
+++ b/src/data/banners.ts
@@ -17,6 +17,14 @@ export const BANNERS = {
     size: { w: 160, h: 600 },
     note: DISCLOSURE
   },
+  model_mid_rectangle: {
+    img: '/ads/model_mid_rectangle.svg',
+    alt: 'Concierge-guided cam onboarding — unlock now',
+    href_pages: '/startright',
+    href_prod: '/go/model-join.php?src=banner_model_mid&camp=model&date=YYYYMMDD',
+    size: { w: 300, h: 250 },
+    note: DISCLOSURE
+  },
   post_inline_rect: {
     img: '/ads/rect-300x250.svg',
     alt: 'Claim your starter kit',

--- a/src/pages/models.astro
+++ b/src/pages/models.astro
@@ -6,24 +6,30 @@ import { getCollection } from 'astro:content';
 const categories = ['Lighting', 'Conversion', 'Scheduling', 'Aftercare'];
 
 const modelEntries = await getCollection('models');
-const models = modelEntries
-  .filter((entry) => entry.data.featured)
-  .sort((a, b) => {
-    const aOrder = a.data.featuredOrder ?? Number.POSITIVE_INFINITY;
-    const bOrder = b.data.featuredOrder ?? Number.POSITIVE_INFINITY;
 
-    if (aOrder === bOrder) {
-      return a.id.localeCompare(b.id);
+const library = modelEntries.map((entry) => ({
+  name: entry.data.name,
+  slug: entry.id,
+  summary: entry.data.summary,
+  image: entry.data.cardImage ?? entry.data.heroImage,
+  featured: entry.data.featured,
+  featuredOrder: entry.data.featuredOrder ?? Number.POSITIVE_INFINITY,
+  consent: entry.data.consent === true
+}));
+
+const featuredModels = library
+  .filter((entry) => entry.featured)
+  .sort((a, b) => {
+    if (a.featuredOrder === b.featuredOrder) {
+      return a.slug.localeCompare(b.slug);
     }
 
-    return aOrder - bOrder;
-  })
-  .map((entry) => ({
-    name: entry.data.name,
-    slug: entry.id,
-    vibe: entry.data.summary,
-    image: entry.data.cardImage ?? entry.data.heroImage
-  }));
+    return a.featuredOrder - b.featuredOrder;
+  });
+
+const libraryModels = library
+  .filter((entry) => !entry.featured)
+  .sort((a, b) => a.name.localeCompare(b.name));
 ---
 
 <MainLayout
@@ -57,7 +63,7 @@ const models = modelEntries
     </div>
 
     <div class="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
-      {models.map((model, index) => (
+      {featuredModels.map((model, index) => (
         <article
           class="group content-card overflow-hidden"
           style={`animation-delay: ${index * 0.1}s`}
@@ -73,9 +79,10 @@ const models = modelEntries
           </div>
           <div class="mt-6 space-y-3">
             <h2 class="font-display text-2xl text-white">{model.name}</h2>
-            <p class="text-sm text-white/70">{model.vibe}</p>
+            <p class="text-sm text-white/70">{model.summary}</p>
             <a
               class="inline-flex items-center gap-2 text-xs uppercase tracking-[0.35em] text-rose-petal transition hover:text-rose-gold"
+              data-model={model.slug}
               href={withBase(`/models/${model.slug}`)}
             >
               View example ↗
@@ -85,4 +92,52 @@ const models = modelEntries
       ))}
     </div>
   </section>
+
+  {libraryModels.length > 0 && (
+    <section class="space-y-8">
+      <div class="space-y-3">
+        <h2 class="section-heading">Library previews</h2>
+        <p class="max-w-2xl text-sm text-white/60">
+          These additional walkthroughs are staged examples. Full visuals unlock once each creator opts in.
+        </p>
+      </div>
+
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {libraryModels.map((model, index) => (
+          <article
+            class="group content-card overflow-hidden"
+            style={`animation-delay: ${index * 0.08}s`}
+          >
+            <div class="relative overflow-hidden rounded-3xl">
+              <img
+                src={model.image}
+                alt={model.name}
+                loading="lazy"
+                class={`h-60 w-full object-cover transition duration-700 ease-out group-hover:scale-105 ${
+                  model.consent ? 'opacity-90 group-hover:opacity-100' : 'opacity-40 group-hover:opacity-60'
+                }`}
+              />
+              {!model.consent && (
+                <div class="absolute inset-0 bg-gradient-to-t from-midnight via-black/40 to-transparent"></div>
+              )}
+            </div>
+            <div class="mt-6 space-y-3">
+              <h3 class="font-display text-xl text-white">{model.name}</h3>
+              <p class="text-sm text-white/65">{model.summary}</p>
+              <p class="text-xs uppercase tracking-[0.35em] text-white/45">
+                {model.consent ? 'Example ready' : 'Consent pending listing'}
+              </p>
+              <a
+                class="inline-flex items-center gap-2 text-xs uppercase tracking-[0.35em] text-rose-petal transition hover:text-rose-gold"
+                data-model={model.slug}
+                href={withBase(`/models/${model.slug}`)}
+              >
+                {model.consent ? 'View example ↗' : 'View listing ↗'}
+              </a>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  )}
 </MainLayout>

--- a/tests/models-index.test.mjs
+++ b/tests/models-index.test.mjs
@@ -1,0 +1,51 @@
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { readOutputFile, cleanupBuilds } from './utils/build.js';
+
+const readIndex = (mode) => readOutputFile(mode, ['models', 'index.html']);
+
+const extractHref = (html, slug) => {
+  const pattern = new RegExp(`<a[^>]+data-model="${slug}"[^>]+href="([^"]+)"`, 'i');
+  const match = html.match(pattern);
+  return match ? match[1] : undefined;
+};
+
+test('Models index lists featured and library entries', async () => {
+  const { html } = await readIndex('pages');
+
+  assert.ok(html.includes('Example model walkthroughs'), 'should render hero copy');
+  assert.ok(html.includes('Anna Prince'), 'should include featured model');
+  assert.ok(html.includes('Ivy Hart'), 'should include supporting model');
+  assert.ok(
+    html.includes('Consent pending listing'),
+    'should highlight consent pending status for supporting models'
+  );
+});
+
+test('Models index respects deployment base for anchors', async () => {
+  const { html: pagesHtml } = await readIndex('pages');
+  assert.equal(
+    extractHref(pagesHtml, 'anna-prince'),
+    '/naughtycamspot/models/anna-prince',
+    'Pages build should prefix base path for Anna'
+  );
+  assert.equal(
+    extractHref(pagesHtml, 'ivy-hart'),
+    '/naughtycamspot/models/ivy-hart',
+    'Pages build should prefix base path for Ivy'
+  );
+
+  const { html: prodHtml } = await readIndex('prod');
+  assert.equal(
+    extractHref(prodHtml, 'anna-prince'),
+    '/models/anna-prince',
+    'Prod build should use root-relative path for Anna'
+  );
+  assert.equal(
+    extractHref(prodHtml, 'ivy-hart'),
+    '/models/ivy-hart',
+    'Prod build should use root-relative path for Ivy'
+  );
+});
+
+after(cleanupBuilds);

--- a/tests/utils/build.js
+++ b/tests/utils/build.js
@@ -1,0 +1,64 @@
+import { execSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { rm } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..', '..');
+
+const buildCache = new Map();
+const cleanupDirs = new Set();
+
+const resolveOutDirName = (mode) => {
+  if (mode === 'pages') {
+    return 'dist-test-pages';
+  }
+
+  if (mode === 'prod') {
+    return 'dist-test-prod';
+  }
+
+  throw new Error(`Unknown build mode: ${mode}`);
+};
+
+const ensureBuild = async (mode) => {
+  if (buildCache.has(mode)) {
+    return buildCache.get(mode);
+  }
+
+  const outDirName = resolveOutDirName(mode);
+  const outDir = path.join(projectRoot, outDirName);
+  await rm(outDir, { recursive: true, force: true });
+
+  const command =
+    mode === 'pages'
+      ? `npx astro build --config astro.config.pages.mjs --outDir ${outDirName}`
+      : `npx astro build --outDir ${outDirName}`;
+
+  execSync(command, { cwd: projectRoot, stdio: 'pipe' });
+
+  const result = { outDir, outDirName, mode };
+  buildCache.set(mode, result);
+  cleanupDirs.add(outDir);
+  return result;
+};
+
+export const readOutputFile = async (mode, segments) => {
+  if (!Array.isArray(segments)) {
+    throw new TypeError('segments must be an array of path parts');
+  }
+
+  const { outDir } = await ensureBuild(mode);
+  const filePath = path.join(outDir, ...segments);
+  const html = await readFile(filePath, 'utf8');
+  return { html, filePath };
+};
+
+export const cleanupBuilds = async () => {
+  for (const dir of cleanupDirs) {
+    await rm(dir, { recursive: true, force: true });
+  }
+  cleanupDirs.clear();
+  buildCache.clear();
+};


### PR DESCRIPTION
## Summary
- expand the models index to surface both featured walkthroughs and consent-pending library entries
- mark Anna Prince as consented with testimonial data and wire up the missing model mid-rectangle banner slot
- add shared build helpers plus regression tests to validate model index routing under both deployment modes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f5671477e48326a1934d1835c38def