### PR TITLE
feat: rename recommender to StartRight

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ branch has diverged, the script will warn so you can handle the merge manually.
 - Production builds automatically append the `date=YYYYMMDD` stamp and keep the `/go/model-join.php` target.
 - Update the FAQ copy by editing the `faqItems` array in `src/pages/join-models.astro`.
 
-## Starter kit claim flow
+## StartRight kit claim flow
 
 - The Pages-safe instructions live in `src/pages/claim.astro`. It renders the proof checklist and links to the correct claim endpoint depending on the build (Tally on Pages, `/claim/` on ViceTemple) using the shared `getClaimUrl` helper.
 - ViceTemple serves the multipart form from `public/claim/index.php`. Proof uploads are written to `public/claim/uploads/<year>/<month>/` and each submission is appended to `public/claim/claims.log`.

--- a/public/claim/index.php
+++ b/public/claim/index.php
@@ -240,7 +240,7 @@ function build_log_entry(DateTimeImmutable $timestamp, string $relativePath, arr
 function build_email_body(DateTimeImmutable $timestamp, string $relativePath, array $values, string $platformLabel): string
 {
     $lines = [
-        'New starter kit claim received on ' . $timestamp->format('Y-m-d H:i:s T') . '.',
+        'New StartRight kit claim received on ' . $timestamp->format('Y-m-d H:i:s T') . '.',
         '',
         'Name: ' . $values['name'],
         'Email: ' . $values['email'],
@@ -286,8 +286,8 @@ function field_error(array $errors, string $key): string
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Claim Starter Kit | NaughtyCamSpot</title>
-    <meta name="description" content="Upload proof of your signup so the NaughtyCamSpot concierge can release the starter kit." />
+    <title>Claim StartRight kit | NaughtyCamSpot</title>
+    <meta name="description" content="Upload proof of your signup so the NaughtyCamSpot concierge can release the StartRight kit." />
     <style>
       :root {
         color-scheme: dark;
@@ -457,9 +457,9 @@ function field_error(array $errors, string $key): string
   </head>
   <body>
     <main>
-      <h1>Claim your starter kit</h1>
+      <h1>Claim your StartRight kit</h1>
       <p>
-        Submit proof of your signup so the NaughtyCamSpot concierge can release the 14-day starter kit. We verify every claim by
+        Submit proof of your signup so the NaughtyCamSpot concierge can release the 14-day StartRight kit. We verify every claim by
         hand. Weekday responses usually land within 24 hours.
       </p>
 
@@ -539,7 +539,7 @@ function field_error(array $errors, string $key): string
 
       <p class="helper" style="margin-top: 28px;">
         After approval you&apos;ll receive an email with the full kit plus a direct link to the
-        <a href="/starter-kit" style="color: var(--accent);">starter kit overview</a> for quick reference.
+        <a href="/starter-kit" style="color: var(--accent);">StartRight kit overview</a> for quick reference.
       </p>
     </main>
   </body>

--- a/public/claim/success.html
+++ b/public/claim/success.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Starter Kit Claimed | NaughtyCamSpot</title>
-    <meta name="description" content="Your NaughtyCamSpot starter kit claim is confirmed." />
+    <title>StartRight kit Claimed | NaughtyCamSpot</title>
+    <meta name="description" content="Your NaughtyCamSpot StartRight kit claim is confirmed." />
     <style>
       :root {
         color-scheme: dark;
@@ -91,10 +91,10 @@
     <main>
       <h1>Claim received</h1>
       <p>
-        Thanks for sending your proof. The concierge team is reviewing it now. You&apos;ll get the 14-day starter kit from
+        Thanks for sending your proof. The concierge team is reviewing it now. You&apos;ll get the 14-day StartRight kit from
         concierge@naughtycamspot.com as soon as the referral is confirmed.
       </p>
-      <a class="button" href="/starter-kit">Browse starter kit overview</a>
+      <a class="button" href="/starter-kit">Browse StartRight kit overview</a>
       <p class="helper">Need to update your claim? Reply to the confirmation email with extra details or a fresh screenshot.</p>
     </main>
   </body>

--- a/scripts/export-starter-kit.js
+++ b/scripts/export-starter-kit.js
@@ -7,7 +7,7 @@ import puppeteer from 'puppeteer';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, '..');
 const outputDir = join(projectRoot, 'exports');
-const outputPath = join(outputDir, 'starter-kit.pdf');
+const outputPath = join(outputDir, 'startright-kit.pdf');
 const targetUrl = process.env.STARTER_KIT_URL ?? 'http://localhost:4321/starter-kit';
 
 const log = (message) => process.stdout.write(`${message}\n`);
@@ -37,18 +37,18 @@ try {
     }
 
     if (!loaded) {
-      throw lastError ?? new Error('Could not reach starter kit page');
+      throw lastError ?? new Error('Could not reach StartRight kit page');
     }
 
     await mkdir(outputDir, { recursive: true });
     log(`🖨️  Rendering PDF to ${outputPath}`);
     await page.pdf({ path: outputPath, format: 'A4', printBackground: true });
-    log('✅ Starter kit exported');
+    log('✅ StartRight kit exported');
   } finally {
     await browser.close();
   }
 } catch (error) {
-  console.error('Failed to export starter kit PDF');
+  console.error('Failed to export StartRight kit PDF');
   console.error(error);
   process.exitCode = 1;
 }

--- a/src/content/blog/14-day-launch-plan.md
+++ b/src/content/blog/14-day-launch-plan.md
@@ -1,6 +1,6 @@
 ---
 title: '14-Day Launch Plan'
-description: 'Map out the two-week runway we use inside the starter kit to turn new signups into confident, profitable performers.'
+description: 'Map out the two-week runway we use inside the StartRight kit to turn new signups into confident, profitable performers.'
 excerpt: 'Preview the exact 14-day plan the concierge team deploys for new models so you know what happens after your claim clears.'
 publishDate: 2024-10-08
 category: 'Concierge Systems'
@@ -24,10 +24,10 @@ Your official launch lands on day seven. You run the hero script, introduce your
 
 ## Phase 4: Momentum stacking (Days 8–11)
 
-We analyse your first week, then double down. You stream every other day, alternating between your primary and VIP scripts. Between shows you send custom DM touchpoints using the templates from the starter kit.
+We analyse your first week, then double down. You stream every other day, alternating between your primary and VIP scripts. Between shows you send custom DM touchpoints using the templates from the StartRight kit.
 
 ## Phase 5: Expansion (Days 12–14)
 
 We close with a collaboration or themed night, plus a post-launch survey for your top tippers. By day 14 you have baseline conversion data, a refined tip menu, and a concierge debrief scheduled to plan your next milestone.
 
-Secure the starter kit as soon as your signup is approved so we can plug you into the full calendar with templates, pricing ladders, and aftercare scripts.
+Secure the StartRight kit as soon as your signup is approved so we can plug you into the full calendar with templates, pricing ladders, and aftercare scripts.

--- a/src/content/blog/bongacash-model-bounty-tiers.md
+++ b/src/content/blog/bongacash-model-bounty-tiers.md
@@ -26,10 +26,10 @@ Once you have proof, widen the funnel. Host a themed stream where mods can answe
 
 ## Tier three: VIP runway
 
-At this stage, focus on quality control. Tier three referrals trigger higher bounty payouts, but the partners review them carefully. Use the starter kit&apos;s DM templates to follow up with prospects before sending them the link. You want genuinely motivated models joining through you.
+At this stage, focus on quality control. Tier three referrals trigger higher bounty payouts, but the partners review them carefully. Use the StartRight kit&apos;s DM templates to follow up with prospects before sending them the link. You want genuinely motivated models joining through you.
 
 ## Protecting your audience
 
-Never blast raw links without context. Instead, weave the offer into your 14-day runway content so fans see it as a curated opportunity. When you claim your starter kit, we share the compliance cheatsheet that keeps your copy inside Bonga&apos;s guidelines.
+Never blast raw links without context. Instead, weave the offer into your 14-day runway content so fans see it as a curated opportunity. When you claim your StartRight kit, we share the compliance cheatsheet that keeps your copy inside Bonga&apos;s guidelines.
 
 Finally, schedule weekly retros with concierge so we can tweak your copy and track conversion velocity. A steady cadence unlocks the bonuses faster than a messy burst.

--- a/src/content/blog/camsoda-vs-chaturbate-for-beginners.md
+++ b/src/content/blog/camsoda-vs-chaturbate-for-beginners.md
@@ -20,7 +20,7 @@ CamSoda feels like a boutique nightclub. Viewers expect higher production value 
 
 CamSoda usually approves new models within 24 hours if your ID photos are crisp and you list at least one social handle. They prefer performers who already have a brand arc. Chaturbate can take slightly longer but offers immediate access to a sandbox room where you can rehearse while waiting.
 
-For both platforms, keep your sign-up screenshots ready. The concierge team needs them when you submit the starter kit claim so we can match referral IDs.
+For both platforms, keep your sign-up screenshots ready. The concierge team needs them when you submit the StartRight kit claim so we can match referral IDs.
 
 ## Traffic and discovery
 
@@ -32,10 +32,10 @@ Regardless of platform, announce your show schedule through socials and prime yo
 
 CamSoda leans into premium DMs and custom menu sales. Build a tip ladder that escalates toward private show bundles. Chaturbate responds well to gamified countdowns and group goals. Rotate between flirty mini-goals and a hero reward every 20 minutes.
 
-Whichever path you pick, keep your first fourteen days focused on the same rituals so data stays clean. We can tweak your menu after the starter kit rollout if your room energy pulls higher spenders than expected.
+Whichever path you pick, keep your first fourteen days focused on the same rituals so data stays clean. We can tweak your menu after the StartRight kit rollout if your room energy pulls higher spenders than expected.
 
 ## Mod support and safety
 
-Chaturbate has a larger volunteer mod community ready to help, but you must set boundaries around ban policies and pacing. CamSoda offers concierge mod referrals for performers willing to host themed nights. Brief your mod team using the show scripts inside the starter kit so everyone welcomes fans the same way.
+Chaturbate has a larger volunteer mod community ready to help, but you must set boundaries around ban policies and pacing. CamSoda offers concierge mod referrals for performers willing to host themed nights. Brief your mod team using the show scripts inside the StartRight kit so everyone welcomes fans the same way.
 
-Remember: either platform works when you pair it with the 14-day runway. Choose the environment that matches your personality, then lock in the claim flow immediately after signup so we can release the kit without delays.
+Remember: either platform works when you pair it with the 14-day runway. Choose the environment that matches your personality, then lock in the claim flow immediately after signup so we can release the StartRight kit without delays.

--- a/src/content/blog/first-stream-checklist-under-100.md
+++ b/src/content/blog/first-stream-checklist-under-100.md
@@ -16,7 +16,7 @@ Start with the room before touching tech. Wipe down your backdrop, clear clutter
 
 ## Lighting on a budget
 
-Buy two clip-on LED lamps (around $15 each) and a pack of warm diffusion gels. Position one lamp at a 45-degree angle for key light and bounce the second off a white wall as fill. A strand of fairy lights adds depth behind you. These notes are expanded inside the starter kit&apos;s lighting checklist.
+Buy two clip-on LED lamps (around $15 each) and a pack of warm diffusion gels. Position one lamp at a 45-degree angle for key light and bounce the second off a white wall as fill. A strand of fairy lights adds depth behind you. These notes are expanded inside the StartRight kit&apos;s lighting checklist.
 
 ## Audio that flatters
 
@@ -28,6 +28,6 @@ Light a candle that matches your room story—vanilla for cozy, sandalwood for l
 
 ## Final rehearsal
 
-Do a 15-minute dry run using one of the starter kit scripts. Practice your intro line, your first tip goal call-out, and the closing gratitude routine. Capture a screenshot for your claim submission while you rehearse so it&apos;s ready for concierge review.
+Do a 15-minute dry run using one of the StartRight kit scripts. Practice your intro line, your first tip goal call-out, and the closing gratitude routine. Capture a screenshot for your claim submission while you rehearse so it&apos;s ready for concierge review.
 
 You can create magic on a tight budget when every detail is intentional. Use this checklist alongside the full 14-day launch plan we send after your claim clears.

--- a/src/data/banners.ts
+++ b/src/data/banners.ts
@@ -27,7 +27,7 @@ export const BANNERS = {
   },
   post_inline_rect: {
     img: '/ads/rect-300x250.svg',
-    alt: 'Claim your starter kit',
+    alt: 'Claim your StartRight kit',
     href_pages: '/startright',
     href_prod: '/claim/',
     size: { w: 300, h: 250 },

--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -17,7 +17,7 @@ export const NAV_MORE: NavLink[] = [
   { href: '/contests', label: 'Contests' },
   { href: '/models', label: 'Models' },
   { href: '/case-studies', label: 'Case Studies' },
-  { href: '/starter-kit', label: 'Starter Kit' },
+  { href: '/starter-kit', label: 'StartRight kit' },
   { href: '/startright', label: 'Join Models', prodHref: '/join-models' },
   { href: '/claim', label: 'Claim' }
 ];

--- a/src/pages/claim.astro
+++ b/src/pages/claim.astro
@@ -27,22 +27,22 @@ const proofSteps = [
 
 const followUpNotes = [
   'We aim to confirm claims within one business day. Weekends may take a touch longer.',
-  'The starter kit ships from concierge@naughtycamspot.com once the referral clears—add us to your safe senders list so nothing lands in spam.',
-  'You can review the full kit contents any time on the starter kit overview page.'
+  'The StartRight kit ships from concierge@naughtycamspot.com once the referral clears—add us to your safe senders list so nothing lands in spam.',
+  'You can review the full kit contents any time on the StartRight kit overview page.'
 ];
 ---
 
 <MainLayout
-  title="Claim Starter Kit | NaughtyCamSpot"
-  description="Submit proof of your partner signup to unlock the NaughtyCamSpot 14-day starter kit."
+  title="Claim StartRight kit | NaughtyCamSpot"
+  description="Submit proof of your partner signup to unlock the NaughtyCamSpot StartRight kit."
 >
   <section class="content-card space-y-6">
     <div class="space-y-4">
-      <span class="hero-tagline">Starter kit verification</span>
-      <h1 class="font-display text-4xl text-white sm:text-5xl">Claim your 14-day starter kit</h1>
+      <span class="hero-tagline">StartRight kit verification</span>
+      <h1 class="font-display text-4xl text-white sm:text-5xl">Claim your StartRight kit</h1>
       <p class="max-w-2xl text-sm text-white/70">
         Finish your partner signup, gather a screenshot that proves the referral, and send it through this claim flow. We verify
-        every submission manually so your launch plan stays exclusive to active models.
+        every submission manually so your StartRight launch plan stays exclusive to active models.
       </p>
     </div>
     <a
@@ -82,8 +82,8 @@ const followUpNotes = [
     </ul>
     <p class="text-sm text-white/65">
       After you submit the form we surface a direct link to the{' '}
-      <a class="text-rose-gold underline-offset-4 hover:underline" href={withBase('/starter-kit')}>
-        starter kit overview
+        <a class="text-rose-gold underline-offset-4 hover:underline" href={withBase('/starter-kit')}>
+          StartRight kit overview
       </a>{' '}
       so you can download everything immediately. Bookmark it now if you want a sneak peek at the daily prompts, pricing ladders,
       and lighting checklists.

--- a/src/pages/compare.astro
+++ b/src/pages/compare.astro
@@ -67,7 +67,7 @@ const programCards: ProgramCard[] = (programs as Program[]).map((program) => {
       <h1 class="font-display text-4xl text-white sm:text-5xl">Compare cam platforms for new creators</h1>
       <p class="max-w-3xl text-base text-white/70">
         These quick-reference cards show our current onboarding guardrails. Use them to decide where to launch, then join via the
-        guarded links so we can ship your starter kit.
+        guarded links so we can ship your StartRight kit.
       </p>
     </div>
     <div class="grid gap-8 lg:grid-cols-3">

--- a/src/pages/contests.astro
+++ b/src/pages/contests.astro
@@ -46,7 +46,7 @@ const joinHrefProd = `/go/model-join.php?src=contests_banner&camp=contests&date=
       <aside class="space-y-4 rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur-2xl">
         <h2 class="font-display text-xl text-white">Join with our links</h2>
         <p class="text-sm text-white/65">
-          Use the guarded join path so we can verify your account and unlock the starter kit once you send proof.
+          Use the guarded join path so we can verify your account and unlock the StartRight kit once you send proof.
         </p>
         <LinkCTA
           class="border border-rose-gold/60 bg-rose-gold text-midnight"

--- a/src/pages/disclosure.astro
+++ b/src/pages/disclosure.astro
@@ -10,13 +10,13 @@ import MainLayout from '../layouts/MainLayout.astro';
     <h1 class="section-heading">Affiliate Disclosure</h1>
     <p>
       NaughtyCamSpot operates as a referral hub. When you click a link and join a paid cam program, we may earn affiliate
-      commissions. Those commissions fund the free 14-day starter kit you receive after verifying your signup.
+      commissions. Those commissions fund the StartRight kit you receive after verifying your signup.
     </p>
     <ul class="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-5 backdrop-blur-xl text-xs uppercase tracking-[0.3em] text-white/55">
       <li>No employment or agency relationship.</li>
       <li>No guarantee of earnings.</li>
       <li>Accounts remain yours; you can leave anytime.</li>
-      <li>Affiliate links fund the starter kit.</li>
+      <li>Affiliate links fund the StartRight kit.</li>
     </ul>
     <p>
       We do not manage, represent, or promote talent. All content on this site is educational or illustrative. If you have

--- a/src/pages/earnings.astro
+++ b/src/pages/earnings.astro
@@ -59,7 +59,7 @@ const cards = bandEntries.map(([key, bands]) => {
     <div class="space-y-4">
       <h1 class="font-display text-4xl text-white sm:text-5xl">Earnings benchmarks for new creators</h1>
       <p class="max-w-3xl text-base text-white/70">
-        These ranges are illustrative only. They help you calibrate the starter kit focus areas and conversations with our concierge team.
+        These ranges are illustrative only. They help you calibrate the StartRight kit focus areas and conversations with our concierge team.
         Your actual earnings depend on how consistently you apply the levers below.
       </p>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,7 +36,7 @@ const featuredMuse = featuredMuseEntry
       name: featuredMuseEntry.data.name,
       archetype: featuredMuseEntry.data.archetype,
       image: featuredMuseEntry.data.heroImage,
-      quote: `${featuredMuseEntry.data.name}'s walkthrough shows how we format storytelling, offers, and lighting notes inside the starter kit.`,
+      quote: `${featuredMuseEntry.data.name}'s walkthrough shows how we format storytelling, offers, and lighting notes inside the StartRight kit.`,
       story: `${featuredMuseEntry.data.name} lives in our example library so you can see how a polished bio, visuals, and schedule might flow. Use it as inspiration—your accounts stay yours, and nothing here is a promise of promotion.`,
       ctaHref: `/models/${featuredMuseEntry.id}`
     }
@@ -44,7 +44,7 @@ const featuredMuse = featuredMuseEntry
       name: 'Coming Soon',
       archetype: 'Example muse',
       image: 'https://images.unsplash.com/photo-1517841905240-472988babdf9?auto=format&fit=crop&w=960&q=80',
-      quote: 'This placeholder illustrates how we storyboard the starter kit resources you’ll receive after sign-up.',
+        quote: 'This placeholder illustrates how we storyboard the StartRight kit resources you’ll receive after sign-up.',
       story: 'We’re drafting additional example pages to showcase kit tactics. Check back for fresh demos you can borrow from immediately.',
       ctaHref: '/models'
     };

--- a/src/pages/join-models.astro
+++ b/src/pages/join-models.astro
@@ -77,7 +77,7 @@ const onboardingSteps = [
       'Forward the confirmation screenshot or referral code to concierge@naughtycamspot.com so we can match your account to our affiliate record.'
   },
   {
-    title: 'Claim the starter kit',
+    title: 'Claim the StartRight kit',
     detail:
       'Once the referral clears, submit the claim form with your screenshot and delivery notes so the concierge team can ship the launch bundle.',
     cta: {

--- a/src/pages/join.astro
+++ b/src/pages/join.astro
@@ -46,18 +46,18 @@ const howItWorks = [
       'Email a screenshot or your referral code to concierge@naughtycamspot.com so we can confirm the referral credit.'
   },
   {
-    title: 'Receive the starter kit',
+    title: 'Receive the StartRight kit',
     detail:
       'We immediately send the 14-day launch kit: lighting checklist, scripted opener, tip menu, pricing ladders, schedule, and ToS cheatsheet.'
   },
   {
     title: 'Optional Q&A',
     detail:
-      'Need clarification? Reply to the starter-kit email for asynchronous guidance—no hands-on promotion, just answers.'
+      'Need clarification? Reply to the StartRight kit email for asynchronous guidance—no hands-on promotion, just answers.'
   }
 ];
 
-const starterKitItems = [
+const startRightKitItems = [
   'Lighting checklist for webcams and phones',
   'Opening show script with icebreakers',
   'Tip menu with upsell ladders',
@@ -69,7 +69,7 @@ const starterKitItems = [
 const whatWereNot = [
   'Not an agency, manager, or representative',
   'No paid promotions or social boosts promised',
-  'We never take a cut—affiliate links fund the starter kit',
+  'We never take a cut—affiliate links fund the StartRight kit',
   'You own every account and can leave whenever you like'
 ];
 
@@ -77,12 +77,12 @@ const faq = [
   {
     question: 'Who owns the accounts?',
     answer:
-      'You do. Every platform profile stays under your control. We only provide starter resources after you sign up with our links.'
+        'You do. Every platform profile stays under your control. We only provide StartRight resources after you sign up with our links.'
   },
   {
     question: 'Do you guarantee earnings?',
     answer:
-      'No. Results depend on your effort, platform policies, and audience. The starter kit is a guide—not a promise of income.'
+      'No. Results depend on your effort, platform policies, and audience. The StartRight kit is a guide—not a promise of income.'
   },
   {
     question: 'Is this employment or an agency contract?',
@@ -90,7 +90,7 @@ const faq = [
       'No. There is no employment, representation, or agency relationship. We run an affiliate-funded resource hub.'
   },
   {
-    question: 'What happens after the starter kit?',
+    question: 'What happens after the StartRight kit?',
     answer:
       'You can email follow-up questions, share your first payout, and, if you like, provide a one-line testimonial so other models know what to expect.'
   }
@@ -99,15 +99,15 @@ const faq = [
 
 <MainLayout
   title="Join | NaughtyCamSpot"
-  description="Sign up through NaughtyCamSpot affiliate links to unlock the free 14-day cam model starter kit."
+  description="Sign up through NaughtyCamSpot affiliate links to unlock the free 14-day cam model StartRight kit."
 >
   <section class="hero-shell parallax-veil">
     <div class="pointer-events-none absolute inset-0 bg-gradient-to-b from-white/10 via-transparent to-black/60"></div>
     <div class="relative space-y-6">
-      <span class="hero-tagline">Referral starter kit</span>
+      <span class="hero-tagline">Referral StartRight kit</span>
       <h1 class="font-display text-5xl leading-tight text-white sm:text-6xl">Start camming, keep control, claim your kit</h1>
       <p class="max-w-2xl text-base text-white/70">
-        NaughtyCamSpot is a referral + starter-kit hub. Click join, finish the partner program signup with our links, send proof,
+        NaughtyCamSpot is a referral + StartRight kit hub. Click join, finish the partner program signup with our links, send proof,
         and we email the full 14-day launch kit—no promo promises, no management fees.
       </p>
       <LinkCTA
@@ -120,7 +120,7 @@ const faq = [
         data-slot={shouldTrackClicks ? joinSlot : undefined}
         data-camp={shouldTrackClicks ? joinCamp : undefined}
       >
-        Start camming • Free starter kit
+        Start camming • Free StartRight kit
       </LinkCTA>
     </div>
   </section>
@@ -130,7 +130,7 @@ const faq = [
     <p class="text-sm text-white/70">
       Four simple steps keep the process transparent. The full breakdown lives in our
       <a class="text-rose-gold underline-offset-4 hover:underline" href={withBase('/starter-kit')}>
-        starter kit overview
+        StartRight kit overview
       </a>
       so you always know what’s included.
     </p>
@@ -152,7 +152,7 @@ const faq = [
       worksheet for your own brand.
     </p>
     <ul class="grid gap-4 text-sm text-white/70 sm:grid-cols-2">
-      {starterKitItems.map((item) => (
+      {startRightKitItems.map((item) => (
         <li class="rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur-xl">{item}</li>
       ))}
     </ul>
@@ -186,6 +186,6 @@ const faq = [
     <p>No employment or agency relationship.</p>
     <p>No guarantee of earnings.</p>
     <p>Accounts remain yours; you can leave anytime.</p>
-    <p>Affiliate links fund the starter kit.</p>
+    <p>Affiliate links fund the StartRight kit.</p>
   </section>
 </MainLayout>

--- a/src/pages/models.astro
+++ b/src/pages/models.astro
@@ -34,7 +34,7 @@ const libraryModels = library
 
 <MainLayout
   title="Example Models | NaughtyCamSpot"
-  description="Explore example cam model pages that demonstrate how to use the NaughtyCamSpot starter kit templates."
+  description="Explore example cam model pages that demonstrate how to use the NaughtyCamSpot StartRight kit templates."
 >
   <!-- SECTION: Models Hero -->
   <section class="hero-shell parallax-veil">
@@ -43,7 +43,7 @@ const libraryModels = library
       <span class="hero-tagline">Example Library</span>
       <h1 class="font-display text-5xl leading-tight text-white sm:text-6xl">Example model walkthroughs</h1>
       <p class="max-w-2xl text-base text-white/70">
-        These pages are demos, not promotions. Each example highlights how to apply the starter kit’s lighting notes, schedule, and
+        These pages are demos, not promotions. Each example highlights how to apply the StartRight kit’s lighting notes, schedule, and
         conversion ladders. Use them as inspiration while keeping full control of your own accounts.
       </p>
     </div>

--- a/src/pages/models/[slug].astro
+++ b/src/pages/models/[slug].astro
@@ -163,7 +163,7 @@ if (hasConsent && data.range_band) {
               </blockquote>
             )}
             <p class="text-xs uppercase tracking-[0.3em] text-white/55">
-              Demo only • No promotion or representation. Use this layout to craft your own profile once you claim the starter kit.
+              Demo only • No promotion or representation. Use this layout to craft your own profile once you claim the StartRight kit.
             </p>
           </div>
           <div class="space-y-3">

--- a/src/pages/starter-kit.astro
+++ b/src/pages/starter-kit.astro
@@ -115,12 +115,12 @@ const tosCheatsheet = [
 ---
 
 <MainLayout
-  title="Starter Kit | NaughtyCamSpot"
-  description="Preview the free 14-day cam model starter kit you receive after signing up through NaughtyCamSpot affiliate links."
+  title="StartRight kit | NaughtyCamSpot"
+  description="Preview the StartRight kit you receive after signing up through NaughtyCamSpot affiliate links."
 >
   <section class="content-card space-y-6">
-    <span class="hero-tagline">Starter kit preview</span>
-    <h1 class="font-display text-4xl text-white sm:text-5xl">Inside the free 14-day launch kit</h1>
+    <span class="hero-tagline">StartRight kit preview</span>
+    <h1 class="font-display text-4xl text-white sm:text-5xl">Inside the StartRight launch kit</h1>
     <p class="max-w-2xl text-sm text-white/70">
       Submit your signup proof and the concierge team delivers this entire playbook within one business day. Use it as a command centre for your launch runway or print it as a desk-side PDF using the export tool.
     </p>
@@ -131,7 +131,7 @@ const tosCheatsheet = [
         target={claimLinkTarget}
         rel={claimLinkRel}
       >
-        Claim your starter kit
+        Claim your StartRight kit
         {claimLinkIsExternal && <span class="ml-2" aria-hidden="true">↗</span>}
       </a>
       <p class="text-xs uppercase tracking-[0.3em] text-white/45">
@@ -259,7 +259,7 @@ const tosCheatsheet = [
     <p>No employment or agency relationship.</p>
     <p>No guarantee of earnings.</p>
     <p>Accounts remain yours; you can leave anytime.</p>
-    <p>Affiliate links fund the starter kit.</p>
+    <p>Affiliate links fund the StartRight kit.</p>
   </section>
 
   <style>

--- a/src/pages/startright.astro
+++ b/src/pages/startright.astro
@@ -95,7 +95,7 @@ const ensureReasons = (rec: Recommendation) => {
     }
   }
   if (rec.reasons.length < 2) {
-    rec.reasons.push('Starter kit unlock keeps resources flowing.');
+    rec.reasons.push('StartRight kit unlock keeps resources flowing.');
   }
   return rec;
 };
@@ -201,7 +201,7 @@ const clientPrograms = JSON.stringify(
         </a>
       </div>
     </div>
-    <form id="recommend-form" class="grid gap-6 rounded-[32px] border border-white/10 bg-white/5 p-6 backdrop-blur-2xl">
+    <form id="startright-form" class="grid gap-6 rounded-[32px] border border-white/10 bg-white/5 p-6 backdrop-blur-2xl">
       <div class="grid gap-4 sm:grid-cols-2">
         <label class="space-y-2 text-sm text-white/70">
           <span class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Experience level</span>
@@ -259,7 +259,7 @@ const clientPrograms = JSON.stringify(
     </form>
     <section
       class="space-y-6 rounded-[32px] border border-white/10 bg-white/5 p-6 backdrop-blur-2xl"
-      id="recommend-results"
+      id="startright-results"
       data-programs={clientPrograms}
       data-is-pages={import.meta.env.IS_PAGES === 'true' ? 'true' : 'false'}
       data-primary-label={PRIMARY_CTA.label}
@@ -273,7 +273,7 @@ const clientPrograms = JSON.stringify(
         <h2 class="font-display text-3xl text-white">Your best starting points</h2>
         <p class="text-sm text-white/60">Switch the form inputs to refresh this guidance. We pick the top three matches.</p>
       </div>
-      <div class="space-y-5" id="recommendation-list">
+      <div class="space-y-5" id="startright-list">
         {defaultRecommendations.map((result) => (
           <article class="rounded-3xl border border-white/10 bg-black/30 p-5">
             <header class="flex flex-wrap items-center justify-between gap-3">
@@ -333,9 +333,9 @@ const clientPrograms = JSON.stringify(
     </section>
   </section>
   <script is:inline>
-    const form = document.querySelector('#recommend-form');
-    const resultsContainer = document.querySelector('#recommend-results');
-    const list = document.querySelector('#recommendation-list');
+    const form = document.querySelector('#startright-form');
+    const resultsContainer = document.querySelector('#startright-results');
+    const list = document.querySelector('#startright-list');
     if (form && resultsContainer && list) {
     const rawPrograms = JSON.parse(resultsContainer.dataset.programs || '[]');
     const programs = rawPrograms.map((program) => ({
@@ -414,7 +414,7 @@ const clientPrograms = JSON.stringify(
           }
         });
         if (rec.reasons.length < 2) {
-          rec.reasons.push('Starter kit unlock keeps resources flowing.');
+          rec.reasons.push('StartRight kit unlock keeps resources flowing.');
         }
         return rec;
       };


### PR DESCRIPTION
## Summary
- rename the StartRight recommender ids and helper copy to match the brand relaunch
- rebrand the claim flow, kit overview, navigation, and documentation around the StartRight kit
- update supporting content and scripts so marketing materials reference the StartRight kit name

## Testing
- npm ci
- npm run build
- npm test
- npm run build:pages
- npm run test:pages-safety

------
https://chatgpt.com/codex/tasks/task_e_68f569ba341083268510e1666e6a781e