### PR TITLE
Enable BongaCams links on Pages builds

### DIFF
--- a/src/data/programs.json
+++ b/src/data/programs.json
@@ -26,6 +26,7 @@
   {
     "key": "bonga",
     "name": "BongaCams",
+    "type": "model_ref",
     "join_base": "https://bongacash.com/model-ref?c=828873",
     "subid_params": ["s1"],
     "payout": "weekly",
@@ -33,7 +34,7 @@
     "traffic": "high EU/EE",
     "geo": "T1–T4 bounty tiers",
     "best_for": ["GEO-tuned payouts", "regional promos"],
-    "status": "pending"
+    "status": "approved"
   },
   {
     "key": "jasmin",

--- a/src/pages/compare.astro
+++ b/src/pages/compare.astro
@@ -4,6 +4,7 @@ import Notices from '../components/Notices.astro';
 import MainLayout from '../layouts/MainLayout.astro';
 import { PRIMARY_CTA } from '../data/copy';
 import { formatDateStamp } from '../utils/links';
+import { buildPagesJoinHref } from '../utils/programs';
 import programs from '../data/programs.json';
 import { resolveProgramStatusMeta, type ProgramStatus } from '../data/programStatus';
 
@@ -33,8 +34,9 @@ type ProgramCard = Program & {
 
 const dateStamp = formatDateStamp();
 const programCards: ProgramCard[] = (programs as Program[]).map((program) => {
-  const joinHrefProd = `/go/model-join.php?src=compare_${program.key}&camp=compare&date=${dateStamp}`;
-  const joinHrefPages = program.join_base;
+  const slot = `compare_${program.key}`;
+  const joinHrefProd = `/go/model-join.php?src=${slot}&camp=compare&date=${dateStamp}`;
+  const joinHrefPages = buildPagesJoinHref(program, slot);
   const statusMeta = resolveProgramStatusMeta(program.status);
   const joinDisabled =
     !statusMeta.allowsJoin || !/^https?:\/\//i.test(joinHrefPages ?? '');

--- a/src/pages/earnings.astro
+++ b/src/pages/earnings.astro
@@ -4,6 +4,7 @@ import Notices from '../components/Notices.astro';
 import MainLayout from '../layouts/MainLayout.astro';
 import { PRIMARY_CTA } from '../data/copy';
 import { formatDateStamp } from '../utils/links';
+import { buildPagesJoinHref } from '../utils/programs';
 import earnings from '../data/earnings.json';
 import programs from '../data/programs.json';
 import { resolveProgramStatusMeta, type ProgramStatus } from '../data/programStatus';
@@ -28,8 +29,9 @@ const bandLabels: Record<string, string> = {
 
 const cards = bandEntries.map(([key, bands]) => {
   const program = programIndex.get(key);
-  const joinHrefPages = program?.join_base ?? '';
-  const joinHrefProdTemplate = `/go/model-join.php?src=earnings_${key}&camp=earnings&date=YYYYMMDD`;
+  const slot = `earnings_${key}`;
+  const joinHrefPages = buildPagesJoinHref(program, slot);
+  const joinHrefProdTemplate = `/go/model-join.php?src=${slot}&camp=earnings&date=YYYYMMDD`;
   const joinHrefProd = joinHrefProdTemplate.replace('YYYYMMDD', dateStamp);
   const statusMeta = resolveProgramStatusMeta(program?.status ?? 'pending');
   const joinDisabled = !statusMeta.allowsJoin || !/^https?:\/\//i.test(joinHrefPages);

--- a/src/pages/startright.astro
+++ b/src/pages/startright.astro
@@ -7,6 +7,7 @@ import { HERO, PRIMARY_CTA, STARTRIGHT_SKIP } from '../data/copy';
 import programs from '../data/programs.json';
 import { resolveProgramStatusMeta, type ProgramStatus } from '../data/programStatus';
 import { formatDateStamp } from '../utils/links';
+import { buildPagesJoinHref } from '../utils/programs';
 
 const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
 const qs = `?src=${STARTRIGHT_SKIP.tracking.src}&camp=${STARTRIGHT_SKIP.tracking.camp}&date=${today}`;
@@ -15,6 +16,7 @@ interface Program {
   key: string;
   name: string;
   join_base: string;
+  subid_params: string[];
   status: ProgramStatus;
   best_for: string[];
 }
@@ -39,8 +41,9 @@ const skipHrefPages = `${STARTRIGHT_SKIP.pagesHrefBase}${qs}`;
 const skipHrefProd = skipHrefPages;
 
 const basePrograms = (programs as Program[]).map((program) => {
-  const joinHrefPages = program.join_base;
-  const joinHrefProdTemplate = `${modelJoinPath}?src=startright_${program.key}&camp=startright&date=YYYYMMDD`;
+  const slot = `startright_${program.key}`;
+  const joinHrefPages = buildPagesJoinHref(program, slot);
+  const joinHrefProdTemplate = `${modelJoinPath}?src=${slot}&camp=startright&date=YYYYMMDD`;
   const joinHrefProd = buildJoinHref(program.key, dateStamp);
   const statusMeta = resolveProgramStatusMeta(program.status);
 

--- a/src/utils/programs.ts
+++ b/src/utils/programs.ts
@@ -1,0 +1,70 @@
+import type { ProgramStatus } from '../data/programStatus';
+
+type ProgramRecord = {
+  key?: string;
+  join_base?: string;
+  subid_params?: string[];
+  status?: ProgramStatus | (string & {});
+};
+
+const isHttpUrl = (value: string) => /^https?:\/\//i.test(value);
+
+const sanitizeParams = (params: string[] | undefined) =>
+  (params ?? [])
+    .map((param) => param.trim())
+    .filter((param) => param.length > 0);
+
+const safeEncode = (value: string) => encodeURIComponent(value.trim());
+
+export const isProgramApproved = (program?: ProgramRecord | null): boolean =>
+  !!program && program.status === 'approved';
+
+export const buildPagesJoinHref = (
+  program: ProgramRecord | undefined,
+  trackingSlot: string
+): string => {
+  if (!program || typeof program.join_base !== 'string') {
+    return '';
+  }
+
+  const baseHref = program.join_base.trim();
+  if (!baseHref) {
+    return '';
+  }
+
+  const slot = trackingSlot.trim();
+  const params = sanitizeParams(program.subid_params);
+
+  if (!slot || params.length === 0) {
+    return baseHref;
+  }
+
+  if (isHttpUrl(baseHref)) {
+    try {
+      const url = new URL(baseHref);
+      params.forEach((param) => {
+        url.searchParams.set(param, slot);
+      });
+      return url.toString();
+    } catch (error) {
+      // Fall back to manual concatenation below.
+    }
+  }
+
+  const glue = baseHref.includes('?') ? '&' : '?';
+  const query = params
+    .map((param) => `${safeEncode(param)}=${safeEncode(slot)}`)
+    .join('&');
+
+  return `${baseHref}${glue}${query}`;
+};
+
+export const allowsPagesJoin = (program?: ProgramRecord | null): boolean => {
+  if (!isProgramApproved(program)) {
+    return false;
+  }
+
+  const baseHref = typeof program?.join_base === 'string' ? program.join_base.trim() : '';
+  return isHttpUrl(baseHref);
+};
+


### PR DESCRIPTION
## Summary
- mark BongaCams as an approved model_ref program
- ensure Pages builds append tracking subIDs when generating join URLs
- expose the updated links across StartRight, Compare, and Earnings views

## Testing
- npm ci
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f57ef8a7e88326880eab4ef02e44e1