### PR TITLE
feat(startright): route, copy, analytics; make StartRight primary CTA

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -26,13 +26,29 @@ const { post, related } = Astro.props;
 const { Content } = await post.render();
 
 const isPages = import.meta.env.IS_PAGES === 'true';
-const joinHrefPages = PRIMARY_CTA.pagesHref;
-const joinHrefProd = `/go/model-join.php?src=blog_${post.slug}&camp=post&date=${formatDateStamp()}`;
-const joinRel = isPages ? undefined : 'nofollow noreferrer';
-const joinCtaLabel = isPages ? 'Join our concierge roster' : 'Join via tracked concierge';
+const trackingQuery = new URLSearchParams({
+  src: `blog_${post.slug}`,
+  camp: 'post',
+  date: formatDateStamp()
+}).toString();
+
+const buildTrackedHref = (baseHref?: string) => {
+  const trimmed = typeof baseHref === 'string' ? baseHref.trim() : '';
+  const fallback = '/startright';
+  const target = trimmed.length > 0 ? trimmed : fallback;
+  if (!trackingQuery) {
+    return target;
+  }
+  const glue = target.includes('?') ? '&' : '?';
+  return `${target}${glue}${trackingQuery}`;
+};
+
+const joinHrefPages = buildTrackedHref(PRIMARY_CTA.pagesHref);
+const joinHrefProd = buildTrackedHref(PRIMARY_CTA.prodHref);
+const joinCtaLabel = 'Open my StartRight plan';
 const startRightMessage = isPages
-  ? 'Pages builds route through the StartRight concierge hub.'
-  : 'Production routes directly to the on-site StartRight plan.';
+  ? 'Pages builds route through the StartRight concierge hub with post-level tracking.'
+  : 'Production routes directly to the on-site StartRight plan with post-level tracking.';
 ---
 
 <MainLayout
@@ -70,10 +86,8 @@ const startRightMessage = isPages
           class="inline-flex items-center justify-center gap-2 border border-rose-gold/60 bg-rose-gold px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-midnight shadow-glow"
           pagesHref={joinHrefPages}
           prodHref={joinHrefProd}
-          rel={joinRel}
         >
           {joinCtaLabel}
-          {isPages && <span aria-hidden="true">↗</span>}
         </LinkCTA>
         <LinkCTA
           class="border border-white/20 bg-transparent text-white hover:bg-white/10"

--- a/src/pages/recommend.astro
+++ b/src/pages/recommend.astro
@@ -1,4 +1,0 @@
----
-import { Astro } from 'astro';
-Astro.redirect('/startright', 301);
----

--- a/src/pages/recommend.ts
+++ b/src/pages/recommend.ts
@@ -1,0 +1,24 @@
+import type { APIRoute } from 'astro';
+
+const FORWARD_KEYS = ['src', 'camp', 'date'] as const;
+
+const buildTarget = (url: URL) => {
+  const params = new URLSearchParams();
+
+  for (const key of FORWARD_KEYS) {
+    const value = url.searchParams.get(key);
+    if (typeof value === 'string' && value.trim().length > 0) {
+      params.set(key, value);
+    }
+  }
+
+  const query = params.toString();
+  return query ? `/startright?${query}` : '/startright';
+};
+
+export const GET: APIRoute = ({ url, redirect }) => {
+  const target = buildTarget(url);
+  return redirect(target, 301);
+};
+
+export const prerender = true;


### PR DESCRIPTION
## Summary
- redirect /recommend to /startright while preserving tracking params and prerendering the route
- retarget blog CTAs to the StartRight planner with tracking-friendly URLs and refreshed helper copy

## Testing
- npm ci
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f58f51fc88832681a83f343092c91f