### PR TITLE
docs: affiliates inventory and program registry sync

### DIFF
--- a/docs/affiliates.md
+++ b/docs/affiliates.md
@@ -1,13 +1,13 @@
-# Affiliate Programs (model signup focus)
+# Affiliate program inventory
 
-| Program     | Status     | Join URL                                                           | SubID param | Notes |
-|-------------|------------|--------------------------------------------------------------------|-------------|-------|
-| CamSoda     | approved   | https://www.camsoda.com/models?id=naughtycamboss                   | subid       | live |
-| Chaturbate  | approved   | https://chaturbate.com/in/?tour=5zjT&campaign=YIOhf&track=default | track       | live |
-| BongaCams   | apply/enable | https://bongacash.com/model-ref?c=828873                         | s1 (tbc)    | confirm param in panel |
-| LiveJasmin  | apply      | (affiliate program URL)                                           | tbd         | model referral required |
-| Stripchat   | blocked    | —                                                                  | —           | turned down via Stripcash |
-| My.club     | low priority | (program URL)                                                    | tbd         | limited traction |
-| Pornhub     | research   | (model referral?)                                                  | tbd         | verify |
-| OnlyFans    | creator-referral | via model’s own referral                                      | tbd         | use model’s link |
-| ManyVids    | separate   | —                                                                  | —           | handled in video/merch track later |
+| Program    | Status    | Join URL                                                           | SubID param | Notes |
+|------------|-----------|--------------------------------------------------------------------|-------------|-------|
+| CamSoda    | approved  | https://www.camsoda.com/models?id=naughtycamboss                   | subid       | live  |
+| Chaturbate | approved  | https://chaturbate.com/in/?tour=5zjT&campaign=YIOhf&track=default | track       | live  |
+| BongaCams  | approved  | https://bongacash.com/model-ref?c=828873                           | s1          | confirm in panel |
+| LiveJasmin | apply     |                                                                    | tbd         | model referral only |
+| Stripchat  | blocked   | —                                                                  | —           | declined by Stripcash |
+| My.club    | low_prio  |                                                                    | tbd         | low traction |
+| Pornhub    | research  |                                                                    | tbd         | verify model referral |
+| OnlyFans   | creator   | (use model’s own referral)                                         | tbd         | via creator’s link |
+| ManyVids   | separate  | —                                                                  | —           | in video/merch track |

--- a/schemas/programs.schema.json
+++ b/schemas/programs.schema.json
@@ -6,19 +6,18 @@
     "additionalProperties": false,
     "required": [
       "key",
-      "name",
+      "type",
+      "status",
       "join_base",
-      "subid_params",
-      "payout",
-      "kyc",
-      "traffic",
-      "geo",
-      "best_for",
-      "status"
+      "subid_params"
     ],
     "properties": {
       "key": { "type": "string", "minLength": 1 },
-      "name": { "type": "string", "minLength": 1 },
+      "type": { "type": "string", "enum": ["model_ref", "creator_ref", "video_merch"] },
+      "status": {
+        "type": "string",
+        "enum": ["approved", "apply", "blocked", "low_prio", "research", "creator", "separate", "pending", "low_priority"]
+      },
       "join_base": {
         "type": "string",
         "pattern": "^(?:https?:\\/\\/[^\\s]+)?$",
@@ -27,18 +26,6 @@
       "subid_params": {
         "type": "array",
         "items": { "type": "string", "minLength": 1 }
-      },
-      "payout": { "type": "string", "minLength": 1 },
-      "kyc": { "type": "string", "minLength": 1 },
-      "traffic": { "type": "string", "minLength": 1 },
-      "geo": { "type": "string", "minLength": 1 },
-      "best_for": {
-        "type": "array",
-        "items": { "type": "string", "minLength": 1 }
-      },
-      "status": {
-        "type": "string",
-        "enum": ["approved", "pending", "blocked", "low_priority", "research"]
       }
     }
   }

--- a/src/data/programDetails.ts
+++ b/src/data/programDetails.ts
@@ -1,0 +1,106 @@
+export type ProgramDetail = {
+  name: string;
+  payout?: string;
+  kyc?: string;
+  traffic?: string;
+  geo?: string;
+  best_for?: string[];
+};
+
+export type ResolvedProgramDetail = {
+  name: string;
+  payout: string;
+  kyc: string;
+  traffic: string;
+  geo: string;
+  best_for: string[];
+};
+
+const withDefaults = (detail: ProgramDetail | undefined, key: string): ResolvedProgramDetail => {
+  const base = detail ?? { name: key };
+  return {
+    name: base.name ?? key,
+    payout: base.payout ?? 'TBD',
+    kyc: base.kyc ?? 'TBD',
+    traffic: base.traffic ?? 'TBD',
+    geo: base.geo ?? 'TBD',
+    best_for: Array.isArray(base.best_for) ? base.best_for : []
+  };
+};
+
+export const PROGRAM_DETAILS: Record<string, ProgramDetail> = {
+  camsoda: {
+    name: 'CamSoda',
+    payout: 'weekly',
+    kyc: 'low friction',
+    traffic: 'good in NA',
+    geo: 'T1 US-heavy',
+    best_for: ['fast start', 'simple setup']
+  },
+  chaturbate: {
+    name: 'Chaturbate',
+    payout: 'weekly',
+    kyc: 'medium',
+    traffic: 'very high',
+    geo: 'global',
+    best_for: ['largest audience', 'broad categories']
+  },
+  bonga: {
+    name: 'BongaCams',
+    payout: 'weekly',
+    kyc: 'medium',
+    traffic: 'high EU/EE',
+    geo: 'T1–T4 bounty tiers',
+    best_for: ['GEO-tuned payouts', 'regional promos']
+  },
+  jasmin: {
+    name: 'LiveJasmin',
+    payout: 'twice monthly',
+    kyc: 'strict',
+    traffic: 'high EU premium',
+    geo: 'EU focus, limited US',
+    best_for: ['studio-managed creators', 'premium cam niches']
+  },
+  stripchat: {
+    name: 'Stripchat',
+    payout: 'weekly',
+    kyc: 'medium',
+    traffic: 'global live traffic',
+    geo: 'Global with strong EU/LatAm',
+    best_for: ['interactive cam formats', 'token whales']
+  },
+  myclub: {
+    name: 'My.Club',
+    payout: 'monthly',
+    kyc: 'medium',
+    traffic: 'boutique fanbase',
+    geo: 'T1 studio referrals',
+    best_for: ['high-touch fan clubs', 'established creators']
+  },
+  pornhub: {
+    name: 'Pornhub',
+    payout: 'monthly',
+    kyc: 'strict',
+    traffic: 'massive global',
+    geo: 'Global, content-tiered',
+    best_for: ['multi-platform expansion', 'studio catalog monetization']
+  },
+  onlyfans: {
+    name: 'OnlyFans',
+    payout: 'creator-managed',
+    kyc: 'platform standard',
+    traffic: 'creator-driven',
+    geo: 'Global per fanbase',
+    best_for: ['direct creator referral', 'fan monetization']
+  },
+  manyvids: {
+    name: 'ManyVids',
+    payout: 'biweekly',
+    kyc: 'standard',
+    traffic: 'clip marketplace',
+    geo: 'Global marketplace',
+    best_for: ['video sales', 'merch funnels']
+  }
+};
+
+export const resolveProgramDetail = (key: string): ResolvedProgramDetail => withDefaults(PROGRAM_DETAILS[key], key);

--- a/src/data/programStatus.ts
+++ b/src/data/programStatus.ts
@@ -1,9 +1,13 @@
 export type ProgramStatus =
   | 'approved'
-  | 'pending'
+  | 'apply'
   | 'blocked'
-  | 'low_priority'
-  | 'research';
+  | 'low_prio'
+  | 'research'
+  | 'creator'
+  | 'separate'
+  | 'pending'
+  | 'low_priority';
 
 export type ProgramStatusMeta = {
   label: string;
@@ -34,12 +38,12 @@ export const PROGRAM_STATUS_META: Record<ProgramStatus, ProgramStatusMeta> = {
     joinDisabledLabel: 'Join path ready',
     allowsJoin: true
   },
-  pending: {
-    label: 'Pending',
-    badgeClass: 'bg-amber-300/10 text-amber-200',
-    textClass: 'text-amber-200',
-    disclosure: 'Awaiting final affiliate paperwork.',
-    joinDisabledLabel: 'Join path pending',
+  apply: {
+    label: 'Apply',
+    badgeClass: 'bg-sky-400/10 text-sky-200',
+    textClass: 'text-sky-200',
+    disclosure: 'Apply via partner panel before we can send links.',
+    joinDisabledLabel: 'Application required',
     allowsJoin: false
   },
   blocked: {
@@ -50,7 +54,7 @@ export const PROGRAM_STATUS_META: Record<ProgramStatus, ProgramStatusMeta> = {
     joinDisabledLabel: 'Program blocked',
     allowsJoin: false
   },
-  low_priority: {
+  low_prio: {
     label: 'Low priority',
     badgeClass: 'bg-sky-400/10 text-sky-200',
     textClass: 'text-sky-200',
@@ -64,6 +68,38 @@ export const PROGRAM_STATUS_META: Record<ProgramStatus, ProgramStatusMeta> = {
     textClass: 'text-purple-200',
     disclosure: 'In research — no onboarding yet.',
     joinDisabledLabel: 'Research in progress',
+    allowsJoin: false
+  },
+  creator: {
+    label: 'Creator referral',
+    badgeClass: 'bg-amber-300/10 text-amber-200',
+    textClass: 'text-amber-200',
+    disclosure: 'Use the creator’s own referral tracking.',
+    joinDisabledLabel: 'Creator-managed access',
+    allowsJoin: false
+  },
+  separate: {
+    label: 'Separate track',
+    badgeClass: 'bg-blue-400/10 text-blue-200',
+    textClass: 'text-blue-200',
+    disclosure: 'Handled via separate merch / video onboarding.',
+    joinDisabledLabel: 'Separate track only',
+    allowsJoin: false
+  },
+  pending: {
+    label: 'Pending',
+    badgeClass: 'bg-amber-300/10 text-amber-200',
+    textClass: 'text-amber-200',
+    disclosure: 'Awaiting final affiliate paperwork.',
+    joinDisabledLabel: 'Join path pending',
+    allowsJoin: false
+  },
+  low_priority: {
+    label: 'Low priority',
+    badgeClass: 'bg-sky-400/10 text-sky-200',
+    textClass: 'text-sky-200',
+    disclosure: 'Access reserved for established creators we already manage.',
+    joinDisabledLabel: 'Low-priority access only',
     allowsJoin: false
   }
 };

--- a/src/data/programs.json
+++ b/src/data/programs.json
@@ -1,99 +1,11 @@
 [
-  {
-    "key": "camsoda",
-    "name": "CamSoda",
-    "join_base": "https://www.camsoda.com/models?id=naughtycamboss",
-    "subid_params": ["subid"],
-    "payout": "weekly",
-    "kyc": "low friction",
-    "traffic": "good in NA",
-    "geo": "T1 US-heavy",
-    "best_for": ["fast start", "simple setup"],
-    "status": "approved"
-  },
-  {
-    "key": "chaturbate",
-    "name": "Chaturbate",
-    "join_base": "https://chaturbate.com/in/?tour=5zjT&campaign=YIOhf&track=default",
-    "subid_params": ["track"],
-    "payout": "weekly",
-    "kyc": "medium",
-    "traffic": "very high",
-    "geo": "global",
-    "best_for": ["largest audience", "broad categories"],
-    "status": "approved"
-  },
-  {
-    "key": "bonga",
-    "name": "BongaCams",
-    "type": "model_ref",
-    "join_base": "https://bongacash.com/model-ref?c=828873",
-    "subid_params": ["s1"],
-    "payout": "weekly",
-    "kyc": "medium",
-    "traffic": "high EU/EE",
-    "geo": "T1–T4 bounty tiers",
-    "best_for": ["GEO-tuned payouts", "regional promos"],
-    "status": "approved"
-  },
-  {
-    "key": "jasmin",
-    "name": "Jasmin",
-    "join_base": "",
-    "subid_params": [],
-    "payout": "twice monthly",
-    "kyc": "strict",
-    "traffic": "high EU premium",
-    "geo": "EU focus, limited US",
-    "best_for": ["studio-managed creators", "premium cam niches"],
-    "status": "pending"
-  },
-  {
-    "key": "stripchat",
-    "name": "Stripchat",
-    "join_base": "",
-    "subid_params": [],
-    "payout": "weekly",
-    "kyc": "medium",
-    "traffic": "global live traffic",
-    "geo": "Global with strong EU/LatAm",
-    "best_for": ["interactive cam formats", "token whales"],
-    "status": "blocked"
-  },
-  {
-    "key": "myclub",
-    "name": "My.Club",
-    "join_base": "",
-    "subid_params": [],
-    "payout": "monthly",
-    "kyc": "medium",
-    "traffic": "boutique fanbase",
-    "geo": "T1 studio referrals",
-    "best_for": ["high-touch fan clubs", "established creators"],
-    "status": "low_priority"
-  },
-  {
-    "key": "pornhub",
-    "name": "Pornhub",
-    "join_base": "",
-    "subid_params": [],
-    "payout": "monthly",
-    "kyc": "strict",
-    "traffic": "massive global",
-    "geo": "Global, content-tiered",
-    "best_for": ["multi-platform expansion", "studio catalog monetization"],
-    "status": "research"
-  },
-  {
-    "key": "crakrevenue",
-    "name": "CrakRevenue",
-    "join_base": "",
-    "subid_params": [],
-    "payout": "net 30",
-    "kyc": "strict",
-    "traffic": "CPA + revshare offers",
-    "geo": "Global, offer-specific",
-    "best_for": ["advanced arbitrage", "multi-offer funnels"],
-    "status": "research"
-  }
+  {"key":"camsoda","type":"model_ref","status":"approved","join_base":"https://www.camsoda.com/models?id=naughtycamboss","subid_params":["subid"]},
+  {"key":"chaturbate","type":"model_ref","status":"approved","join_base":"https://chaturbate.com/in/?tour=5zjT&campaign=YIOhf&track=default","subid_params":["track"]},
+  {"key":"bonga","type":"model_ref","status":"approved","join_base":"https://bongacash.com/model-ref?c=828873","subid_params":["s1"]},
+  {"key":"jasmin","type":"model_ref","status":"apply","join_base":"","subid_params":[]},
+  {"key":"stripchat","type":"model_ref","status":"blocked","join_base":"","subid_params":[]},
+  {"key":"myclub","type":"model_ref","status":"low_prio","join_base":"","subid_params":[]},
+  {"key":"pornhub","type":"model_ref","status":"research","join_base":"","subid_params":[]},
+  {"key":"onlyfans","type":"creator_ref","status":"creator","join_base":"","subid_params":[]},
+  {"key":"manyvids","type":"video_merch","status":"separate","join_base":"","subid_params":[]}
 ]

--- a/src/pages/compare.astro
+++ b/src/pages/compare.astro
@@ -4,22 +4,20 @@ import Notices from '../components/Notices.astro';
 import MainLayout from '../layouts/MainLayout.astro';
 import { PRIMARY_CTA } from '../data/copy';
 import { formatDateStamp } from '../utils/links';
-import { buildPagesJoinHref } from '../utils/programs';
+import { buildPagesJoinHref, allowsPagesJoin, isProgramApproved, type ProgramRecord } from '../utils/programs';
 import programs from '../data/programs.json';
+import { resolveProgramDetail, type ResolvedProgramDetail } from '../data/programDetails';
 import { resolveProgramStatusMeta, type ProgramStatus } from '../data/programStatus';
 
-interface Program {
+type ProgramEntry = ProgramRecord & {
   key: string;
-  name: string;
+  type: string;
+  status: ProgramStatus;
   join_base: string;
   subid_params: string[];
-  payout: string;
-  kyc: string;
-  traffic: string;
-  geo: string;
-  best_for: string[];
-  status: ProgramStatus;
-}
+};
+
+type Program = ProgramEntry & ResolvedProgramDetail;
 
 type ProgramCard = Program & {
   joinHrefPages: string;
@@ -33,31 +31,41 @@ type ProgramCard = Program & {
 };
 
 const dateStamp = formatDateStamp();
-const programCards: ProgramCard[] = (programs as Program[]).map((program) => {
-  const slot = `compare_${program.key}`;
-  const joinHrefProd = `/go/model-join.php?src=${slot}&camp=compare&date=${dateStamp}`;
-  const joinHrefPages = buildPagesJoinHref(program, {
-    slot,
-    src: slot,
-    camp: 'compare',
-    date: dateStamp
-  });
-  const statusMeta = resolveProgramStatusMeta(program.status);
-  const joinDisabled =
-    !statusMeta.allowsJoin || !/^https?:\/\//i.test(joinHrefPages ?? '');
+const enrichedPrograms: Program[] = (programs as ProgramEntry[]).map((program) => ({
+  ...program,
+  ...resolveProgramDetail(program.key)
+}));
 
-  return {
-    ...program,
-    joinHrefPages,
-    joinHrefProd,
-    joinDisabled,
-    subidLine: program.subid_params.length > 0 ? `SubID params: ${program.subid_params.join(', ')}` : 'No subID params yet.',
-    statusLabel: statusMeta.label,
-    statusBadgeClass: statusMeta.badgeClass,
-    statusDisclosure: statusMeta.disclosure,
-    joinDisabledLabel: statusMeta.joinDisabledLabel
-  };
-});
+const programCards: ProgramCard[] = enrichedPrograms
+  .filter((program) => isProgramApproved(program) && allowsPagesJoin(program))
+  .map((program) => {
+    const slot = `compare_${program.key}`;
+    const joinHrefPages = buildPagesJoinHref(program, {
+      slot,
+      src: slot,
+      camp: 'compare',
+      date: dateStamp
+    });
+    const joinHrefProd = joinHrefPages;
+    const statusMeta = resolveProgramStatusMeta(program.status);
+    const joinDisabled =
+      !statusMeta.allowsJoin || !allowsPagesJoin(program) || !/^https?:\/\//i.test(joinHrefPages ?? '');
+
+    return {
+      ...program,
+      joinHrefPages,
+      joinHrefProd,
+      joinDisabled,
+      subidLine:
+        program.subid_params.length > 0
+          ? `SubID params: ${program.subid_params.slice(0, 1).join(', ')}`
+          : 'No subID params yet.',
+      statusLabel: statusMeta.label,
+      statusBadgeClass: statusMeta.badgeClass,
+      statusDisclosure: statusMeta.disclosure,
+      joinDisabledLabel: statusMeta.joinDisabledLabel
+    };
+  });
 ---
 
 <MainLayout title="Compare cam platforms" description="Compare cam platforms tailored for new creators launching with NaughtyCamSpot.">

--- a/src/pages/startright.astro
+++ b/src/pages/startright.astro
@@ -5,68 +5,67 @@ import SEO from '../components/SEO.astro';
 import MainLayout from '../layouts/MainLayout.astro';
 import { HERO, PRIMARY_CTA, STARTRIGHT_SKIP } from '../data/copy';
 import programs from '../data/programs.json';
+import { resolveProgramDetail, type ResolvedProgramDetail } from '../data/programDetails';
 import { resolveProgramStatusMeta, type ProgramStatus } from '../data/programStatus';
 import { formatDateStamp } from '../utils/links';
-import { buildPagesJoinHref } from '../utils/programs';
+import {
+  buildPagesJoinHref,
+  allowsPagesJoin,
+  isProgramApproved,
+  type ProgramRecord
+} from '../utils/programs';
 
 const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
 const qs = `?src=${STARTRIGHT_SKIP.tracking.src}&camp=${STARTRIGHT_SKIP.tracking.camp}&date=${today}`;
 
-interface Program {
+type ProgramEntry = ProgramRecord & {
   key: string;
-  name: string;
+  type: string;
+  status: ProgramStatus;
   join_base: string;
   subid_params: string[];
-  status: ProgramStatus;
-  best_for: string[];
-}
+};
+
+type EnrichedProgram = ProgramEntry & ResolvedProgramDetail;
 
 const canonicalPath = '/startright';
-
-const rawBasePath = typeof import.meta.env.BASE_URL === 'string' ? import.meta.env.BASE_URL : '/';
-const normalizedBasePath = rawBasePath.replace(/\/+$/, '');
-const goBase = `${normalizedBasePath}/go`.replace(/\/{2,}/g, '/');
-const modelJoinPath = `${goBase}/model-join.php`.replace(/\/{2,}/g, '/');
-
-const buildJoinHref = (key: string, date: string) => {
-  const params = new URLSearchParams({
-    src: `startright_${key}`,
-    camp: 'startright',
-    date,
-    slot: `startright_${key}`
-  });
-  return `${modelJoinPath}?${params.toString()}`;
-};
 
 const dateStamp = formatDateStamp();
 const skipHrefPages = `${STARTRIGHT_SKIP.pagesHrefBase}${qs}`;
 const skipHrefProd = skipHrefPages;
 
-const basePrograms = (programs as Program[]).map((program) => {
-  const slot = `startright_${program.key}`;
-  const joinHrefPages = buildPagesJoinHref(program, {
-    slot,
-    src: slot,
-    camp: 'startright',
-    date: dateStamp
-  });
-  const joinHrefProdTemplate = `${modelJoinPath}?src=${slot}&camp=startright&date=YYYYMMDD`;
-  const joinHrefProd = buildJoinHref(program.key, dateStamp);
-  const statusMeta = resolveProgramStatusMeta(program.status);
+const enrichedPrograms: EnrichedProgram[] = (programs as ProgramEntry[]).map((program) => ({
+  ...program,
+  ...resolveProgramDetail(program.key)
+}));
 
-  return {
-    ...program,
-    joinHrefPages,
-    joinHrefProd,
-    joinHrefProdTemplate,
-    joinDisabled: !statusMeta.allowsJoin || !/^https?:\/\//i.test(joinHrefPages ?? ''),
-    statusLabel: statusMeta.label,
-    statusTextClass: statusMeta.textClass,
-    statusDisclosure: statusMeta.disclosure,
-    joinDisabledLabel: statusMeta.joinDisabledLabel,
-    statusAllowsJoin: statusMeta.allowsJoin
-  };
-});
+const basePrograms = enrichedPrograms
+  .filter((program) => isProgramApproved(program) && allowsPagesJoin(program))
+  .map((program) => {
+    const slot = `startright_${program.key}`;
+    const joinHrefPages = buildPagesJoinHref(program, {
+      slot,
+      src: slot,
+      camp: 'startright',
+      date: dateStamp
+    });
+    const joinHrefProd = joinHrefPages;
+    const statusMeta = resolveProgramStatusMeta(program.status);
+    const joinDisabled =
+      !statusMeta.allowsJoin || !allowsPagesJoin(program) || !/^https?:\/\//i.test(joinHrefPages ?? '');
+
+    return {
+      ...program,
+      joinHrefPages,
+      joinHrefProd,
+      joinDisabled,
+      statusLabel: statusMeta.label,
+      statusTextClass: statusMeta.textClass,
+      statusDisclosure: statusMeta.disclosure,
+      joinDisabledLabel: statusMeta.joinDisabledLabel,
+      statusAllowsJoin: statusMeta.allowsJoin
+    };
+  });
 
 const defaultAnswers = {
   experience: 'new',
@@ -265,7 +264,6 @@ const clientPrograms = JSON.stringify(
       id="startright-results"
       data-programs={clientPrograms}
       data-is-pages={import.meta.env.IS_PAGES === 'true' ? 'true' : 'false'}
-      data-model-join-path={modelJoinPath}
       data-primary-label={PRIMARY_CTA.label}
       data-primary-pages={PRIMARY_CTA.pagesHref}
       data-primary-prod={PRIMARY_CTA.prodHref}
@@ -362,7 +360,6 @@ const clientPrograms = JSON.stringify(
         const now = new Date();
         return `${now.getUTCFullYear()}${String(now.getUTCMonth() + 1).padStart(2, '0')}${String(now.getUTCDate()).padStart(2, '0')}`;
       };
-      const modelJoinPath = resultsContainer.dataset.modelJoinPath || '/go/model-join.php';
       const searchParams = new URLSearchParams(window.location.search);
       const inboundSrc = searchParams.get('src') || '';
       const inboundCamp = searchParams.get('camp') || '';
@@ -375,21 +372,6 @@ const clientPrograms = JSON.stringify(
           date: inboundDate || date,
           slot: defaults.slot
         };
-      };
-      const buildProdHref = (key) => {
-        const defaults = {
-          src: `startright_${key}`,
-          camp: 'startright',
-          date: formatDateStamp(),
-          slot: `startright_${key}`
-        };
-        const tracking = computeTracking(defaults);
-        const params = new URLSearchParams();
-        if (tracking.src) params.set('src', tracking.src);
-        if (tracking.camp) params.set('camp', tracking.camp);
-        if (tracking.date) params.set('date', tracking.date);
-        if (tracking.slot) params.set('slot', tracking.slot);
-        return `${modelJoinPath}?${params.toString()}`;
       };
       const applyTrackingToPath = (href, defaults) => {
         if (!href || /^https?:\/\//i.test(href)) {
@@ -424,7 +406,6 @@ const clientPrograms = JSON.stringify(
       const evaluate = (answers) => {
         const items = programs.map((program) => ({
           ...program,
-          joinHrefProd: buildProdHref(program.key),
           score: 1,
           reasons: []
         }));

--- a/src/partials/home/TrustedPrograms.astro
+++ b/src/partials/home/TrustedPrograms.astro
@@ -1,29 +1,32 @@
 ---
 import programs from '../../data/programs.json';
+import { resolveProgramDetail } from '../../data/programDetails';
+import { resolveProgramStatusMeta, type ProgramStatus } from '../../data/programStatus';
 import { withBase } from '../../utils/links';
+import { allowsPagesJoin, isProgramApproved, type ProgramRecord } from '../../utils/programs';
 
-interface Program {
+type ProgramEntry = ProgramRecord & {
   key: string;
-  name: string;
-  payout: string;
-  traffic: string;
-  best_for: string[];
-  status: string;
-}
+  type: string;
+  status: ProgramStatus;
+  join_base: string;
+  subid_params: string[];
+};
 
-const formatStatus = (status: string) =>
-  status
-    .split('_')
-    .map((token) => (token ? token[0]?.toUpperCase() + token.slice(1) : token))
-    .join(' ');
-
-const curatedPrograms = (programs as Program[])
-  .filter((program) => !['blocked', 'research'].includes(program.status))
-  .slice(0, 4)
+const curatedPrograms = (programs as ProgramEntry[])
   .map((program) => ({
     ...program,
-    statusLabel: formatStatus(program.status)
-  }));
+    ...resolveProgramDetail(program.key)
+  }))
+  .filter((program) => isProgramApproved(program) && allowsPagesJoin(program))
+  .slice(0, 4)
+  .map((program) => {
+    const statusMeta = resolveProgramStatusMeta(program.status);
+    return {
+      ...program,
+      statusLabel: statusMeta.label
+    };
+  });
 ---
 <section class="border-t border-white/5 bg-midnight/40 px-6 py-20">
   <div class="mx-auto flex max-w-6xl flex-col gap-12">

--- a/src/utils/programs.ts
+++ b/src/utils/programs.ts
@@ -1,6 +1,6 @@
-import type { ProgramStatus } from '../data/programStatus';
+import type { ProgramStatus } from "../data/programStatus";
 
-type ProgramRecord = {
+export type ProgramRecord = {
   key?: string;
   join_base?: string;
   subid_params?: string[];
@@ -18,36 +18,42 @@ type TrackingInput =
 
 const isHttpUrl = (value: string) => /^https?:\/\//i.test(value);
 
-const sanitizeParams = (params: string[] | undefined) =>
-  (params ?? [])
+const sanitizeParams = (params: string[] | undefined) => {
+  const sanitized = (params ?? [])
     .map((param) => param.trim())
     .filter((param) => param.length > 0);
+  return sanitized.length > 0 ? [sanitized[0]] : [];
+};
 
 const safeEncode = (value: string) => encodeURIComponent(value.trim());
 
 export const isProgramApproved = (program?: ProgramRecord | null): boolean =>
-  !!program && program.status === 'approved';
+  !!program && program.status === "approved";
 
 export const buildPagesJoinHref = (
   program: ProgramRecord | undefined,
-  tracking: TrackingInput
+  tracking: TrackingInput,
 ): string => {
-  if (!program || typeof program.join_base !== 'string') {
-    return '';
+  if (!program || typeof program.join_base !== "string") {
+    return "";
   }
 
   const baseHref = program.join_base.trim();
   if (!baseHref) {
-    return '';
+    return "";
   }
 
-  const slot = typeof tracking === 'string' ? tracking.trim() : (tracking.slot ?? '').trim();
-  const src = typeof tracking === 'string' ? slot : (tracking.src ?? slot).trim();
-  const camp = typeof tracking === 'string' ? '' : (tracking.camp ?? '').trim();
-  const date = typeof tracking === 'string' ? '' : (tracking.date ?? '').trim();
+  const slot =
+    typeof tracking === "string"
+      ? tracking.trim()
+      : (tracking.slot ?? "").trim();
+  const src =
+    typeof tracking === "string" ? slot : (tracking.src ?? slot).trim();
+  const camp = typeof tracking === "string" ? "" : (tracking.camp ?? "").trim();
+  const date = typeof tracking === "string" ? "" : (tracking.date ?? "").trim();
   const params = sanitizeParams(program.subid_params);
 
-  const subidValue = [src, camp, date].filter(Boolean).join('-') || slot;
+  const subidValue = [src, camp, date].filter(Boolean).join("-") || slot;
 
   if (!slot || params.length === 0) {
     return baseHref;
@@ -65,10 +71,10 @@ export const buildPagesJoinHref = (
     }
   }
 
-  const glue = baseHref.includes('?') ? '&' : '?';
+  const glue = baseHref.includes("?") ? "&" : "?";
   const query = params
     .map((param) => `${safeEncode(param)}=${safeEncode(subidValue)}`)
-    .join('&');
+    .join("&");
 
   return `${baseHref}${glue}${query}`;
 };
@@ -78,7 +84,7 @@ export const allowsPagesJoin = (program?: ProgramRecord | null): boolean => {
     return false;
   }
 
-  const baseHref = typeof program?.join_base === 'string' ? program.join_base.trim() : '';
+  const baseHref =
+    typeof program?.join_base === "string" ? program.join_base.trim() : "";
   return isHttpUrl(baseHref);
 };
-


### PR DESCRIPTION
## Summary
- refresh `docs/affiliates.md` and the program schema/data to match the current affiliate inventory
- add structured program details and update StartRight/Compare/TrustedPrograms to hydrate from the registry and only render approved links
- ensure Pages builds use direct join URLs with the correct subID parameter

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f59a6d0cac8326a5951687df319c83