### PR TITLE
Add blog inline rectangle and end strip banners

### DIFF
--- a/WORK_QUEUE.md
+++ b/WORK_QUEUE.md
@@ -8,6 +8,6 @@
 - Preserve `?src=...&camp=...&date=YYYYMMDD`.
 
 ## Queue
-- [ ] #41 Blog banner placements (inline rectangle + end strip)
+- [x] #41 Blog banner placements (inline rectangle + end strip)
 - [ ] #40 Blog index + client search
 - [ ] #44 Finalize “More” dropdown + mobile accordion

--- a/src/components/KitBuilder.astro
+++ b/src/components/KitBuilder.astro
@@ -233,13 +233,6 @@ const defaultLanguage = languageOptions[0]?.value ?? 'EN';
 
     const fieldClass = 'space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-glow backdrop-blur-xl sm:p-8';
 
-    const timezoneField = form?.querySelector('select[name="timezone"]') ?? null;
-    const hoursField = form?.querySelector('input[name="hours"]') ?? null;
-    const languageField = form?.querySelector('select[name="language"]') ?? null;
-    const platformInputs = Array.from(
-      form?.querySelectorAll('input[name="platforms"]') ?? []
-    ).filter((input) => input instanceof HTMLInputElement);
-
     const detectTimezoneRegion = () => {
       try {
         const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/src/data/banners.ts
+++ b/src/data/banners.ts
@@ -32,6 +32,14 @@ export const BANNERS = {
     href_prod: '/claim/',
     size: { w: 300, h: 250 },
     note: 'Free 14-day kit after signup proof.'
+  },
+  post_end_strip: {
+    img: '/ads/post_end_strip.svg',
+    alt: 'Finish with the StartRight concierge plan',
+    href_pages: '/startright',
+    href_prod: '/go/model-join.php?src=banner_blog_end&camp=blog&date=YYYYMMDD',
+    size: { w: 900, h: 200 },
+    note: DISCLOSURE
   }
 } as const;
 

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -77,7 +77,8 @@ const startRightMessage = isPages
       <Content />
     </div>
 
-    <BannerSlot id="post_inline_rect" class="mt-6" />
+    <!-- SLOT: post_inline_rect -->
+    <BannerSlot id="post_inline_rect" class="mt-6" showNote />
 
     <div class="content-card space-y-5">
       <h2 class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Continue your launch</h2>
@@ -99,6 +100,9 @@ const startRightMessage = isPages
       <p class="text-xs text-white/50">{startRightMessage}</p>
     </div>
   </article>
+
+  <!-- SLOT: post_end_strip -->
+  <BannerSlot id="post_end_strip" class="mt-16" showNote />
 
   <!-- SECTION: Related Posts -->
   <section class="space-y-6">


### PR DESCRIPTION
## Summary
- register the post end strip banner slot with production tracking parameters
- render the inline rectangle and new end strip placements on blog posts with disclosure notes
- remove duplicated KitBuilder field declarations that broke the build

## Testing
- npm ci && npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f5b4b6b1f88326bcc838659c844f42