### PR TITLE
Remove Compare nav link and add home hero to compare page

### DIFF
--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -7,7 +7,6 @@ export type NavLink = {
 
 export const NAV_PRIMARY: NavLink[] = [
   { href: '/', label: 'Home' },
-  { href: '/compare', label: 'Compare' },
   { href: '/startright', label: 'StartRight' },
   { href: '/earnings', label: 'Earnings' },
   { href: '/blog', label: 'Blog' }

--- a/src/pages/compare.astro
+++ b/src/pages/compare.astro
@@ -2,6 +2,7 @@
 import LinkCTA from '../components/LinkCTA.astro';
 import Notices from '../components/Notices.astro';
 import MainLayout from '../layouts/MainLayout.astro';
+import Hero from '../partials/home/Hero.astro';
 import { PRIMARY_CTA } from '../data/copy';
 import { formatDateStamp } from '../utils/links';
 import { buildPagesJoinHref, allowsPagesJoin, isProgramApproved, type ProgramRecord } from '../utils/programs';
@@ -69,6 +70,7 @@ const programCards: ProgramCard[] = enrichedPrograms
 ---
 
 <MainLayout title="Compare cam platforms" description="Compare cam platforms tailored for new creators launching with NaughtyCamSpot.">
+  <Hero />
   <section class="space-y-8">
     <Notices />
     <div class="space-y-4">


### PR DESCRIPTION
## Summary
- remove the Compare link from the primary navigation data
- reuse the home Hero banner at the top of the /compare page for consistent messaging

## Testing
- npm ci
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f5c3bba79c83268e9a7608382299be