### PR TITLE
Add gated training vault with VIP briefs

### DIFF
--- a/WORK_QUEUE.md
+++ b/WORK_QUEUE.md
@@ -4,4 +4,4 @@
 
 ## Queue
 - [x] #42 Remove Compare from nav; add home banner to /compare
-- [ ] #45 Design protected Training area + VIP-only posts (design doc, then implement)
+- [x] #45 Design protected Training area + VIP-only posts (design doc, then implement)

--- a/docs/training-area.md
+++ b/docs/training-area.md
@@ -1,0 +1,47 @@
+# Training area access design (#45)
+
+## Overview
+We need a concierge-only training hub that lives on the public site but stays hidden behind an access gate. The hub should hold VIP briefs, launch runbooks, and other sensitive playbooks without exposing them to casual visitors. The feature ships in two layers: a design note that captures the structure and guardrails, and a front-end implementation that obeys those rules.
+
+## Goals
+- Provide a dedicated `/training` destination that matches the site aesthetic and highlights what VIP members receive.
+- Require a concierge-provided access code before revealing the library or any VIP posts.
+- Keep VIP posts out of the blog index while giving them their own hero, categories, and related article browsing once unlocked.
+- Avoid shipping real secrets in the static HTML and make it easy to rotate access codes without a redeploy.
+
+## Access control
+- The gate expects an environment variable called `PUBLIC_TRAINING_ACCESS_HASH` that stores the lowercase hex digest of the allowed access code hashed with SHA-256.
+- Visitors type their code into the gate. The client hashes the submitted value with `crypto.subtle.digest('SHA-256', ...)` and compares it to the stored hash.
+- When a match occurs, the digest is cached in `localStorage` under the key `ncs.training.access` so the visitor can browse freely until they clear storage.
+- If the environment variable is empty, the interface shows a concierge contact prompt instead of a broken form.
+- Hash verification happens entirely in the browser; the clear-text code never appears in the built output.
+
+## Content architecture
+- Introduce a new `training` content collection under `src/content/training` with metadata that mirrors the blog (title, excerpt, category, publish date, author, imagery).
+- VIP posts live in Markdown files. Astro renders the Markdown once the gate unlocks; until then the post body stays hidden.
+- Training posts receive dedicated routes at `/training/<slug>` and never mingle with `/blog` routes or components.
+- Hero art and excerpts use the same aesthetic as the main blog to keep design cohesion while making the training area feel intentional.
+
+## Page layout
+### `/training`
+- Hero banner summarising the concierge vault and telling visitors what unlocks provide.
+- Gate card with an inline form, error state, and success confirmation.
+- Once authenticated, a grid of VIP-only posts appears with metadata and deep links to individual posts.
+
+### `/training/<slug>`
+- Individual hero with category, author, and publish date.
+- Body copy rendered inside the gate once the access code is confirmed.
+- Related posts rail so VIPs can jump to other briefs without returning to the index.
+
+## Implementation checklist
+1. Add the `training` collection schema in `src/content/config.ts` and seed it with at least two Markdown posts.
+2. Create a reusable gate component that renders the form, stores the hash in `localStorage`, and toggles protected slots once the hash matches.
+3. Build `src/pages/training/index.astro` to pull the new collection, wrap the grid in the gate component, and surface a concierge contact CTA when the hash is missing.
+4. Build `src/pages/training/[slug].astro` to render individual posts inside the same gate component and show related VIP content below the fold.
+5. Add the Training link to the more-menu navigation set so concierge partners can find it once authorised.
+6. Document the environment variable in this design note and reuse the script across index and detail views to keep behaviour consistent.
+
+## Future enhancements
+- Replace the static access code with a real membership service (Supabase Auth, Clerk, or a concierge portal) once infrastructure exists.
+- Encrypt the Markdown payload in the build step so even view-source cannot read the VIP content without the key.
+- Track unlock events in analytics to measure VIP engagement and rotate codes automatically when membership changes.

--- a/src/components/TrainingAccess.astro
+++ b/src/components/TrainingAccess.astro
@@ -1,0 +1,200 @@
+---
+const {
+  accessHash = '',
+  storageKey = 'ncs.training.access',
+  title = 'Concierge access required',
+  description =
+    'Enter the VIP code provided by your concierge producer to unlock the private training vault.',
+  inputLabel = 'Access code',
+  buttonLabel = 'Unlock training',
+  successMessage = 'Vault unlocked. Welcome back to the concierge floor.',
+  contactLabel = 'Need the code? Email concierge@naughtycamspot.com.',
+  contactHref = 'mailto:concierge@naughtycamspot.com'
+} = Astro.props;
+---
+<section
+  class="content-card space-y-6"
+  data-training-access
+  data-access-hash={accessHash}
+  data-storage-key={storageKey}
+>
+  <div class="space-y-4" data-training-locked>
+    <div class="space-y-2">
+      <h2 class="text-sm font-semibold uppercase tracking-[0.35em] text-rose-petal/70">{title}</h2>
+      <p class="text-base text-white/70">{description}</p>
+    </div>
+    <form class="space-y-4" data-gate-form novalidate>
+      <label class="block space-y-2">
+        <span class="text-xs uppercase tracking-[0.3em] text-white/50">{inputLabel}</span>
+        <input
+          type="password"
+          inputmode="text"
+          autocomplete="off"
+          spellcheck="false"
+          class="w-full rounded-full border border-white/20 bg-white/5 px-5 py-3 text-sm text-white shadow-inner shadow-black/50 focus:border-rose-gold focus:outline-none"
+          placeholder="••••••"
+          data-gate-input
+        />
+      </label>
+      <button
+        type="submit"
+        class="inline-flex items-center justify-center gap-2 rounded-full border border-rose-gold/60 bg-rose-gold px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-midnight shadow-glow transition hover:border-rose-gold/80 hover:bg-rose-gold/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-gold"
+        data-gate-submit
+      >
+        {buttonLabel}
+      </button>
+    </form>
+    <p class="hidden text-sm text-rose-200/80" data-gate-error>
+      That code did not match. Double-check with concierge and try again.
+    </p>
+    <p class="text-xs text-white/50">
+      <a class="underline decoration-dotted underline-offset-4 transition hover:text-rose-petal" href={contactHref}>
+        {contactLabel}
+      </a>
+    </p>
+  </div>
+  <div class="hidden space-y-4" data-training-missing>
+    <h2 class="text-sm font-semibold uppercase tracking-[0.35em] text-rose-petal/70">Access temporarily offline</h2>
+    <p class="text-base text-white/70">
+      The concierge team has not published the current access code. Reach out to
+      <a class="underline decoration-dotted underline-offset-4 transition hover:text-rose-petal" href={contactHref}
+        >concierge@naughtycamspot.com</a
+      >
+      for the latest credentials.
+    </p>
+  </div>
+  <div class="hidden space-y-4" data-training-success>
+    <p class="text-sm font-semibold uppercase tracking-[0.3em] text-rose-petal/80">{successMessage}</p>
+  </div>
+  <div class="hidden space-y-6" data-training-content>
+    <slot />
+  </div>
+  <noscript>
+    <p class="text-sm text-white/60">
+      JavaScript is required to unlock the training library. Enable scripts or contact the concierge team for an offline brief.
+    </p>
+  </noscript>
+</section>
+<script is:inline>
+  {`(function(){
+  const shell = document.querySelector('[data-training-access]');
+  if (!shell) {
+    return;
+  }
+
+  const requiredHash = (shell.getAttribute('data-access-hash') || '').trim();
+  const storageKey = (shell.getAttribute('data-storage-key') || 'ncs.training.access').trim();
+  const locked = shell.querySelector('[data-training-locked]');
+  const missing = shell.querySelector('[data-training-missing]');
+  const success = shell.querySelector('[data-training-success]');
+  const content = shell.querySelector('[data-training-content]');
+  const form = shell.querySelector('[data-gate-form]');
+  const input = shell.querySelector('[data-gate-input]');
+  const submit = shell.querySelector('[data-gate-submit]');
+  const error = shell.querySelector('[data-gate-error]');
+
+  const setState = (state) => {
+    const isUnlocked = state === 'unlocked';
+    const isMissing = state === 'missing';
+    if (locked) {
+      locked.classList.toggle('hidden', isUnlocked || isMissing);
+    }
+    if (content) {
+      content.classList.toggle('hidden', !isUnlocked);
+    }
+    if (missing) {
+      missing.classList.toggle('hidden', !isMissing);
+    }
+    if (success) {
+      success.classList.toggle('hidden', !isUnlocked);
+    }
+  };
+
+  if (!requiredHash) {
+    setState('missing');
+    return;
+  }
+
+  const toHex = (buffer) => {
+    return Array.from(new Uint8Array(buffer))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  };
+
+  const digest = async (value) => {
+    if (!window.crypto || !window.crypto.subtle) {
+      throw new Error('Hashing unavailable');
+    }
+    const encoder = new TextEncoder();
+    const encoded = encoder.encode(value);
+    const hash = await window.crypto.subtle.digest('SHA-256', encoded);
+    return toHex(hash);
+  };
+
+  const markUnlocked = () => {
+    setState('unlocked');
+    if (error) {
+      error.classList.add('hidden');
+    }
+    try {
+      window.localStorage.setItem(storageKey, requiredHash);
+    } catch (storageError) {
+      console.warn('Unable to persist training access flag', storageError);
+    }
+  };
+
+  try {
+    const cached = window.localStorage.getItem(storageKey);
+    if (cached && cached === requiredHash) {
+      markUnlocked();
+      return;
+    }
+  } catch (storageError) {
+    console.warn('Unable to read training access flag', storageError);
+  }
+
+  form?.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!input) {
+      return;
+    }
+
+    const code = input.value.trim();
+    if (code.length === 0) {
+      input.focus();
+      return;
+    }
+
+    const toggleSubmitting = (active) => {
+      form.classList.toggle('opacity-70', active);
+      form.classList.toggle('pointer-events-none', active);
+      if (submit) {
+        submit.classList.toggle('animate-pulse', active);
+      }
+    };
+
+    toggleSubmitting(true);
+
+    try {
+      const hashed = await digest(code);
+      if (hashed === requiredHash) {
+        markUnlocked();
+        return;
+      }
+      if (error) {
+        error.classList.remove('hidden');
+      }
+    } catch (hashError) {
+      console.error('Training gate failed to hash code', hashError);
+      if (error) {
+        error.classList.remove('hidden');
+        error.textContent = 'We could not verify that code. Please try again later or contact concierge.';
+      }
+    } finally {
+      toggleSubmitting(false);
+      input.value = '';
+      input.focus();
+    }
+  });
+})();`}
+</script>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -53,4 +53,19 @@ const blog = defineCollection({
   })
 });
 
-export const collections = { models, blog };
+const training = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    excerpt: z.string(),
+    publishDate: z.date(),
+    category: z.string(),
+    author: z.string(),
+    heroImage: z.string().url(),
+    heroImageAlt: z.string().optional(),
+    cardImage: z.string().url().optional()
+  })
+});
+
+export const collections = { models, blog, training };

--- a/src/content/training/launch-room-blueprint.md
+++ b/src/content/training/launch-room-blueprint.md
@@ -1,0 +1,40 @@
+---
+title: 'Launch Room Blueprint'
+description: 'Stage the concierge launch room so your first 90 minutes online feel like a produced television pilot.'
+excerpt: 'Follow the lighting, scripting, and concierge staffing blueprint to launch with poise and a fully warmed VIP funnel.'
+publishDate: 2025-01-20
+category: 'Launch Operations'
+author: 'Marco, Studio Lead'
+heroImage: 'https://images.unsplash.com/photo-1515165562835-c4c1b572ef13?auto=format&fit=crop&w=1600&q=80'
+heroImageAlt: 'Studio set with dramatic lights'
+cardImage: 'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=1200&q=80'
+---
+
+The launch room is your control tower. Before you ever hit “start streaming,” the concierge pit choreographs the first 90 minutes so nothing feels improvised.
+
+## Set the room
+- Double-layer blackout curtains behind the key light to eliminate spill.
+- Mount a silent fan aimed at your back to keep temperature steady under studio lights.
+- Place the VIP incentive table within arm’s reach and keep a Polaroid camera loaded for surprise drops.
+
+## Script the operators
+- Concierge lead owns the show rundown, DM cadence, and sponsor shoutouts.
+- Mod 1 runs the welcome gate, tagging high-spend handles and logging them in the VIP sheet.
+- Mod 2 monitors merch triggers, Discord chatter, and highlights that feed the after-show recap.
+
+## Pre-roll funnel
+- Send a 3-hour “doors open soon” DM to every concierge-tagged VIP. Include the private playlist and arrival cue.
+- Publish a teaser clip to socials with subtitles and a `00:45` runtime. Caption references the concierge line for VIP escalations.
+- Queue the first upsell call-to-action as a pinned message with the concierge line as backup.
+
+## Live show cadence
+1. **00:00–00:10** — Concierge lead does the high-energy welcome while Mod 1 sweeps the chat.
+2. **00:10–00:25** — Showcase the offer ladder; Mod 2 tags every call-in who hits the `silver` rung.
+3. **00:25–00:40** — VIP spotlight moment with a scripted toast, then the concierge lead transitions to the hero activity.
+4. **00:40–00:60** — Run the hero activity. Concierge lead drops audio cues while Mod 1 handles DM escalations.
+5. **00:60–00:90** — Cooldown with gratitude circle, release next stream’s teaser, and book three concierge follow-ups.
+
+### Reset protocol
+- Archive the chat transcript, DM highlights, and merch receipts into the launch folder within 30 minutes.
+- Update the concierge CRM tile with results: revenue by tier, VIP attendance, and next experiments.
+- Draft a 90-second voice memo for VIPs recapping the wins and naming the next concierge incentive.

--- a/src/content/training/vip-retention-cadence.md
+++ b/src/content/training/vip-retention-cadence.md
@@ -1,0 +1,38 @@
+---
+title: 'VIP Retention Cadence'
+description: 'Build a 30-day concierge calendar that keeps top tippers pampered, tracked, and primed for renewals.'
+excerpt: 'Use the four-phase retention cadence to rotate high-touch scripts, concierge outreach, and reward drops for your VIP tier.'
+publishDate: 2025-02-02
+category: 'VIP Systems'
+author: 'Lena, Concierge Director'
+heroImage: 'https://images.unsplash.com/photo-1517245386807-bb43f82c33c4?auto=format&fit=crop&w=1600&q=80'
+heroImageAlt: 'Concierge desk with warm lighting'
+cardImage: 'https://images.unsplash.com/photo-1499951360447-b19be8fe80f5?auto=format&fit=crop&w=1200&q=80'
+---
+
+VIP loyalty does not happen accidentally. It’s the outcome of scripted touchpoints layered with concierge feedback loops. The cadence below keeps your high rollers feeling indulged without burning through staff hours.
+
+## Phase 1 — Signal review (Days 1–7)
+- Audit nightly spend and DM replies. Flag anyone who hit 70% of your monthly VIP threshold.
+- Ship personalised thank-you videos within 24 hours. Attach one concierge insight they unlocked (floor plan, mod prompt, or show note).
+- Update the VIP tracker with their preferred incentives, favourite show themes, and red lines.
+
+## Phase 2 — Momentum scripting (Days 8–15)
+- Run a 20-minute VIP-only warmup show. Soft-release an upsell menu and log reactions.
+- Rotate concierge prompts through your mods so greetings stay fresh. Each mod tags responses in the retention sheet.
+- Drop a “72-hour priority pass” DM. Reward fast responders with a five-minute cam-to-cam promise.
+
+## Phase 3 — Spotlight conversion (Days 16–23)
+- Invite the top three spenders to co-design a limited bundle. Document the bundle in the VIP CRM tile.
+- Publish a concierge-written teaser to social stories highlighting the upcoming VIP spotlight show.
+- During the show, deploy three scripted moments: a gratitude toast, a reveal anchored to their bundle, and an on-stream testimonial ask.
+
+## Phase 4 — Renewal handshake (Days 24–30)
+- Run post-show concierge calls to lock the next month’s intent. Capture verbal commitments in the tracker.
+- Send a luxe mailer (handwritten card + scented insert). Include a QR that routes to the next VIP calendar.
+- Publish a private audio note recapping wins and naming the first perk of the new month.
+
+### Implementation checklist
+1. Refresh the VIP CRM tile each Monday with new sentiment notes.
+2. Pre-write gratitude scripts for each tier so on-air delivery feels natural.
+3. Align mod staffing around VIP nights to ensure the white-glove pacing holds.

--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -17,6 +17,7 @@ export const NAV_MORE: NavLink[] = [
   { href: '/models', label: 'Models' },
   { href: '/case-studies', label: 'Case Studies' },
   { href: '/starter-kit', label: 'StartRight kit' },
+  { href: '/training', label: 'Training' },
   { href: '/startright', label: 'Join Models', prodHref: '/join-models' },
   { href: '/claim', label: 'Claim' }
 ];

--- a/src/pages/training/[slug].astro
+++ b/src/pages/training/[slug].astro
@@ -1,0 +1,95 @@
+---
+import { getCollection } from 'astro:content';
+import MainLayout from '../../layouts/MainLayout.astro';
+import TrainingAccess from '../../components/TrainingAccess.astro';
+import { withBase } from '../../utils/links';
+
+const formatDate = (date: Date) =>
+  new Intl.DateTimeFormat('en-US', { month: 'long', day: '2-digit', year: 'numeric' }).format(date);
+
+export async function getStaticPaths() {
+  const posts = await getCollection('training');
+  const sorted = posts.slice().sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime());
+
+  return sorted.map((entry) => ({
+    params: { slug: entry.slug },
+    props: {
+      post: entry,
+      related: sorted.filter((item) => item.slug !== entry.slug).slice(0, 3)
+    }
+  }));
+}
+
+const { post, related } = Astro.props;
+const { Content } = await post.render();
+const accessHash =
+  typeof import.meta.env.PUBLIC_TRAINING_ACCESS_HASH === 'string'
+    ? import.meta.env.PUBLIC_TRAINING_ACCESS_HASH.trim()
+    : '';
+const formattedDate = formatDate(post.data.publishDate);
+---
+
+<MainLayout
+  title={`${post.data.title} | Training Vault`}
+  description={post.data.description}
+>
+  <article class="space-y-8">
+    <header class="hero-shell parallax-veil">
+      <div class="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 via-transparent to-black/70"></div>
+      <div class="relative space-y-4">
+        <span class="hero-tagline">{post.data.category}</span>
+        <h1 class="font-display text-5xl text-white sm:text-6xl">{post.data.title}</h1>
+        <div class="flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.3em] text-white/60">
+          <span>By {post.data.author}</span>
+          <span>{formattedDate}</span>
+        </div>
+      </div>
+    </header>
+  </article>
+
+  <TrainingAccess
+    accessHash={accessHash}
+    title="Unlock VIP brief"
+    description="Confirm your concierge code to view the full training breakdown."
+    buttonLabel="Reveal brief"
+    successMessage="Unlocked. Review the concierge notes below."
+  >
+    <article class="space-y-10">
+      <div class="glass overflow-hidden rounded-[42px]">
+        <img src={post.data.heroImage} alt={post.data.heroImageAlt ?? post.data.title} class="h-80 w-full object-cover" loading="lazy" />
+      </div>
+      <div class="space-y-6 text-base leading-relaxed text-white/70">
+        <Content />
+      </div>
+    </article>
+
+    {related.length > 0 && (
+      <section class="space-y-6">
+        <h2 class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Related VIP briefs</h2>
+        <div class="grid gap-6 sm:grid-cols-3">
+          {related.map((item) => (
+            <a class="content-card space-y-3" href={withBase(`/training/${item.slug}`)}>
+              <img
+                src={item.data.cardImage ?? item.data.heroImage}
+                alt={item.data.heroImageAlt ?? item.data.title}
+                class="h-40 w-full rounded-3xl object-cover"
+                loading="lazy"
+              />
+              <div class="space-y-1">
+                <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">{item.data.category}</p>
+                <p class="font-display text-xl text-white">{item.data.title}</p>
+                <p class="text-xs uppercase tracking-[0.3em] text-white/40">{formatDate(item.data.publishDate)}</p>
+              </div>
+            </a>
+          ))}
+        </div>
+      </section>
+    )}
+  </TrainingAccess>
+
+  <p class="mt-12 text-xs uppercase tracking-[0.35em] text-white/50">
+    <a class="transition hover:text-rose-petal" href={withBase('/training')}>
+      ← Back to training index
+    </a>
+  </p>
+</MainLayout>

--- a/src/pages/training/index.astro
+++ b/src/pages/training/index.astro
@@ -1,0 +1,101 @@
+---
+import { getCollection } from 'astro:content';
+import MainLayout from '../../layouts/MainLayout.astro';
+import TrainingAccess from '../../components/TrainingAccess.astro';
+import { withBase } from '../../utils/links';
+
+const accessHash =
+  typeof import.meta.env.PUBLIC_TRAINING_ACCESS_HASH === 'string'
+    ? import.meta.env.PUBLIC_TRAINING_ACCESS_HASH.trim()
+    : '';
+
+const rawPosts = await getCollection('training');
+const posts = rawPosts
+  .slice()
+  .sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime())
+  .map((entry, index) => ({
+    slug: entry.slug,
+    title: entry.data.title,
+    excerpt: entry.data.excerpt,
+    category: entry.data.category,
+    author: entry.data.author,
+    date: new Intl.DateTimeFormat('en-US', {
+      month: 'long',
+      day: '2-digit',
+      year: 'numeric'
+    }).format(entry.data.publishDate),
+    image: entry.data.cardImage ?? entry.data.heroImage,
+    animationDelay: index * 0.1
+  }));
+
+const totalPosts = posts.length;
+---
+
+<MainLayout
+  title="Training Vault | NaughtyCamSpot"
+  description="Protected concierge training hub for NaughtyCamSpot partners. Unlock VIP launch briefs, retention cadences, and private ops notes."
+>
+  <section class="hero-shell parallax-veil">
+    <div class="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/50 via-transparent to-black/60"></div>
+    <div class="relative space-y-6">
+      <span class="hero-tagline">Concierge Vault</span>
+      <h1 class="font-display text-5xl leading-tight text-white sm:text-6xl">Training &amp; VIP Systems</h1>
+      <p class="max-w-2xl text-base text-white/70">
+        Concierge-only briefs covering launch choreography, VIP retention, and elite guest experience tactics. Unlock the vault with
+        your access code to view the full library.
+      </p>
+    </div>
+  </section>
+
+  <TrainingAccess
+    accessHash={accessHash}
+    title="Concierge access required"
+    description="Enter the code provided by your concierge producer to unlock the private training library."
+    buttonLabel="Unlock library"
+    successMessage="Access granted. Scroll for the latest concierge briefs."
+  >
+    {totalPosts === 0 ? (
+      <p class="text-sm text-white/70">
+        The concierge team is composing the first VIP briefs. Check back soon or message your producer for early drafts.
+      </p>
+    ) : (
+      <div class="space-y-6">
+        <div class="space-y-2">
+          <h2 class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">VIP Briefs</h2>
+          <p class="text-base text-white/70">
+            {totalPosts === 1
+              ? '1 concierge note is available right now.'
+              : `${totalPosts} concierge notes are ready in the vault.`}
+          </p>
+        </div>
+        <div class="grid gap-6 sm:grid-cols-2">
+          {posts.map((post) => (
+            <article
+              class="content-card group overflow-hidden"
+              style={`animation-delay: ${post.animationDelay}s`}
+            >
+              <div class="relative overflow-hidden rounded-3xl">
+                <img src={post.image} alt={post.title} class="h-52 w-full object-cover" loading="lazy" />
+                <div class="absolute inset-0 bg-gradient-to-t from-midnight via-transparent to-transparent opacity-80 transition group-hover:opacity-60"></div>
+              </div>
+              <div class="mt-6 space-y-3">
+                <span class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">{post.category}</span>
+                <h3 class="font-display text-2xl text-white">{post.title}</h3>
+                <p class="text-sm text-white/70">{post.excerpt}</p>
+                <div class="flex flex-wrap items-center justify-between gap-3 text-xs text-white/50">
+                  <span>{post.author} • {post.date}</span>
+                  <a
+                    class="uppercase tracking-[0.35em] text-rose-petal transition hover:text-rose-gold"
+                    href={withBase(`/training/${post.slug}`)}
+                  >
+                    Open Brief ↗
+                  </a>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    )}
+  </TrainingAccess>
+</MainLayout>


### PR DESCRIPTION
## Summary
- document the training vault architecture and access controls
- add a reusable TrainingAccess gate plus a new training content collection with VIP posts
- build gated training index/detail pages and expose the Training link in the navigation

## Testing
- npm ci
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f5cb65843883268427f298888b9fdd